### PR TITLE
Add support for zerocopy fields

### DIFF
--- a/ingot-examples/src/tests.rs
+++ b/ingot-examples/src/tests.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::{choices::*, packets::*};
-use core::net::{Ipv4Addr, Ipv6Addr};
 use ingot::{
     ethernet::{Ethernet, EthernetMut, EthernetRef, Ethertype, ValidEthernet},
     geneve::GeneveRef,
@@ -12,8 +11,8 @@ use ingot::{
         ValidIpv6,
     },
     types::{
-        HeaderLen, HeaderParse, NetworkRepr, NextLayer, ParseError, Parsed,
-        Read,
+        HeaderLen, HeaderParse, Ipv4Addr, Ipv6Addr, NetworkRepr, NextLayer,
+        ParseError, Parsed, Read,
     },
     udp::{Udp, UdpMut, UdpRef, ValidUdp},
 };

--- a/ingot-macros/src/lib.rs
+++ b/ingot-macros/src/lib.rs
@@ -66,7 +66,7 @@ pub fn derive_parse(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// `MyHdr`), and defines a packed wire-format equivalent (`ValidMyHdr`).
 ///
 /// ```rust,ignore
-/// use ingot::types::primitives::*;
+/// use ingot::types::{Ipv4Addr, primitives::*};
 ///
 /// #[derive(Ingot)]
 /// #[ingot(impl_default)]
@@ -78,11 +78,13 @@ pub fn derive_parse(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///     pub field4: u20be,
 ///     #[ingot(var_len = "field3 * 4")]
 ///     pub field5: Vec<u8>,
+///     #[ingot(zerocopy)]
+///     pub field6: Ipv4Addr,
 /// }
 /// ```
 ///
-/// Fields are defined in terms of *primitive integer types*, variable-length
-/// byteslices (`Vec<u8>`), and parsed sub-headers.
+/// Fields are defined in terms of *primitive integer types*, `zerocopy` types,
+/// variable-length byteslices (`Vec<u8>`), and parsed sub-headers.
 /// Primitive types are:
 /// * Signed/unsigned integers <= 1 byte (`u1`, `i8`).
 /// * Longer integers with a defined endianness (`u27be`).

--- a/ingot-macros/src/lib.rs
+++ b/ingot-macros/src/lib.rs
@@ -105,6 +105,13 @@ pub fn derive_parse(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// * `#[ingot(is = "<type>")]` – allows the use of higher-level types and conversions
 ///   of fields using the `NetworkRepr` trait. The field will be parsed as the primitive
 ///   `<type>` before converting to the desired type.
+/// * `#[ingot(zerocopy)]` indicates that the field may be cast directly from a
+///   slice of bytes.
+///   - The field's type must implement `FromBytes`, `IntoBytes`,
+///     `KnownLayout`, and `Immutable` from the `zerocopy` crate.
+///   - The field's type must have alignment of 1 byte.
+///   - The beginning of the field must be byte-aligned within the packet
+///   - This attribute is incompatible with `is`, `var_len`, and `subparse`.
 /// * `#[ingot(default = <expr>)]` – specifies a default value for this field
 ///   when deriving `Default`.
 /// * `#[ingot(next_layer)]` – indicates that this field is to be used as a hint

--- a/ingot-macros/src/packet/mod.rs
+++ b/ingot-macros/src/packet/mod.rs
@@ -56,6 +56,8 @@ pub struct SubparseSpec {
 pub struct FieldArgs {
     is: Option<Type>,
     #[darling(default)]
+    zerocopy: bool,
+    #[darling(default)]
     next_layer: bool,
     var_len: Option<Expr>,
     #[darling(default)]
@@ -110,20 +112,27 @@ impl ValidField {
         )
     }
 
-    fn length_fn(&self) -> Option<&Expr> {
+    fn length_fn(&self) -> Option<Expr> {
         match &self.state {
             FieldState::FixedWidth { .. } => None,
-            FieldState::VarWidth { length_fn } => Some(length_fn),
-            FieldState::Parsable { length_fn, .. } => length_fn.as_ref(),
+            FieldState::Zerocopy => {
+                let ty = &self.user_ty;
+                let tokens = quote! { core::mem::size_of::<#ty>() };
+                let expr: Expr = syn::parse2(tokens)
+                    .expect("Failed to parse tokens into Expr");
+                Some(expr)
+            }
+            FieldState::VarWidth { length_fn } => Some(length_fn.clone()),
+            FieldState::Parsable { length_fn, .. } => length_fn.clone(),
         }
     }
 
     fn resolved_length_fn(
         &self,
         ctx: &StructParseDeriveCtx,
-    ) -> Option<(TokenStream, &Expr)> {
+    ) -> Option<(TokenStream, Expr)> {
         // basic idea:
-        //  * If no lenghth fn is specified, exit.
+        //  * If no length fn is specified, exit.
         //  * Identify all variables used in `length_fn` matching field idents
         //     which exist in a prior chunk.
         //  * generate a preamble which defines local variables with those
@@ -141,7 +150,7 @@ impl ValidField {
         }
 
         let mut vis = IdentVisitor::default();
-        vis.visit_expr(length_fn);
+        vis.visit_expr(&length_fn);
 
         let defns = vis
             .0
@@ -192,6 +201,8 @@ enum FieldState {
         /// stuck it in a bitfield
         bitfield_info: Option<PrimitiveInBitfield>,
     },
+    /// Type which may be read directly from bytes using `zerocopy` traits
+    Zerocopy,
     /// Byte-aligned (sz + offset) variable-width fields.
     /// (Really, just byte arrays.)
     VarWidth { length_fn: Expr },
@@ -209,11 +220,17 @@ enum FieldState {
 }
 
 #[derive(Clone, Debug)]
+struct ChunkSize {
+    bytes: usize,
+    zc_fields: Vec<Type>,
+}
+
+#[derive(Clone, Debug)]
 enum ChunkState {
     FixedWidth {
         /// Names of all fields contained in this block.
         fields: Vec<Ident>,
-        size_bytes: usize,
+        size: ChunkSize,
         fw_idx: usize,
     },
     /// Byte-aligned (sz + offset) variable-width fields.
@@ -251,34 +268,46 @@ impl ChunkState {
                     fields.iter().map(|id| ctx.validated.get(id).unwrap())
                 {
                     let field = field.borrow();
-                    let FieldState::FixedWidth {
-                        analysis, bitfield_info, ..
-                    } = &field.state
-                    else {
-                        panic!("non fixed-width field in fixed-width chunk")
-                    };
+                    match &field.state {
+                        FieldState::FixedWidth {
+                            analysis,
+                            bitfield_info,
+                            ..
+                        } => {
+                            if let Some(bf) = bitfield_info {
+                                let parent_bf = bf.parent_field.borrow();
+                                let f_ident = parent_bf.ident.clone();
+                                let n_bytes = parent_bf.n_bits / 8;
 
-                    if let Some(bf) = bitfield_info {
-                        let parent_bf = bf.parent_field.borrow();
-                        let f_ident = parent_bf.ident.clone();
-                        let n_bytes = parent_bf.n_bits / 8;
+                                if last_seen_bf.as_ref() != Some(&f_ident) {
+                                    zc_fields.push(quote! {
+                                        pub #f_ident: [u8; #n_bytes]
+                                    });
+                                    last_seen_bf = Some(f_ident);
+                                }
+                            } else {
+                                let ident = &field.ident;
+                                let ty = analysis.to_zerocopy_type().expect(
+                                    "guaranteed defined for U8/U16/U32/U64/...",
+                                );
+                                let zc_repr = ty.repr;
 
-                        if last_seen_bf.as_ref() != Some(&f_ident) {
-                            zc_fields.push(quote! {
-                                pub #f_ident: [u8; #n_bytes]
-                            });
-                            last_seen_bf = Some(f_ident);
+                                zc_fields.push(quote! {
+                                    pub #ident: #zc_repr
+                                });
+                            }
                         }
-                    } else {
-                        let ident = &field.ident;
-                        let ty = analysis.to_zerocopy_type().expect(
-                            "guaranteed defined for U8/U16/U32/U64/...",
-                        );
-                        let zc_repr = ty.repr;
+                        FieldState::Zerocopy => {
+                            let ident = &field.ident;
+                            let ty = &field.user_ty;
+                            zc_fields.push(quote! {
+                                pub #ident: #ty
+                            });
+                        }
 
-                        zc_fields.push(quote! {
-                            pub #ident: #zc_repr
-                        });
+                        _ => {
+                            panic!("non fixed-width field in fixed-width chunk")
+                        }
                     }
                 }
 
@@ -408,17 +437,24 @@ impl StructParseDeriveCtx {
         let mut nominated_next_header = None;
         let mut chunk_layout = vec![];
 
+        #[derive(Default)]
+        struct ChunkSizeBits {
+            bits: usize,
+            zc_fields: Vec<Type>,
+        }
+
         let mut fws_written = 0;
         let sub_field_idx = RefCell::new(0);
-        let curr_chunk_bits: RefCell<Option<(usize, Vec<Ident>)>> = None.into();
+        let curr_chunk_size: RefCell<Option<(ChunkSizeBits, Vec<Ident>)>> =
+            None.into();
 
         let mut finalize_chunk = || {
             let mut q = sub_field_idx.borrow_mut();
             *q += 1;
-            let bits = curr_chunk_bits.take();
+            let size = curr_chunk_size.take();
 
-            match bits {
-                Some((len, _)) if len % 8 != 0 => Err(Error::new(
+            match size {
+                Some((size, _)) if size.bits % 8 != 0 => Err(Error::new(
                     validated_order
                         .borrow()
                         .last()
@@ -428,15 +464,24 @@ impl StructParseDeriveCtx {
                         .span(),
                     format!(
                         "fields are not byte-aligned -- \
-                        total {len}b at fixed-len boundary"
+                        total {}b {}at fixed-len boundary",
+                        size.bits,
+                        if size.zc_fields.is_empty() {
+                            ""
+                        } else {
+                            "(plus zerocopy fields) "
+                        }
                     ),
                 )),
-                Some((len, fields)) => {
+                Some((size, fields)) => {
                     let fw_idx = fws_written;
                     fws_written += 1;
                     chunk_layout.push(ChunkState::FixedWidth {
                         fields,
-                        size_bytes: len / 8,
+                        size: ChunkSize {
+                            bytes: size.bits / 8,
+                            zc_fields: size.zc_fields,
+                        },
                         fw_idx,
                     });
                     Ok(())
@@ -452,7 +497,8 @@ impl StructParseDeriveCtx {
                         FieldState::Parsable { .. } => {
                             ChunkState::Parsable(ident)
                         }
-                        FieldState::FixedWidth { .. } => unreachable!(),
+                        FieldState::FixedWidth { .. }
+                        | FieldState::Zerocopy => unreachable!(),
                     };
                     chunk_layout.push(chunk);
                     Ok(())
@@ -474,37 +520,59 @@ impl StructParseDeriveCtx {
             let user_ty = field.ty.clone();
 
             let state = match (
+                &field.zerocopy,
                 &field.subparse,
                 &field.var_len,
                 field.next_layer,
             ) {
-                (Some(SubparseSpec { on_next_layer }), length_fn, false) => {
+                (true, None, None, false) => {
+                    let mut ccs_ref = curr_chunk_size.borrow_mut();
+                    let (curr_chunk_size, curr_chunk_fields) =
+                        ccs_ref.get_or_insert((ChunkSizeBits::default(), vec![]));
+
+                    if curr_chunk_size.bits % 8 != 0 {
+                        return Err(Error::new(
+                            user_ty.span(),
+                            "zerocopy types must be byte-aligned at their start and end",
+                        ));
+                    }
+                    curr_chunk_fields.push(field_ident.clone());
+                    curr_chunk_size.zc_fields.push(user_ty.clone());
+                    FieldState::Zerocopy
+                }
+                (true, ..) => {
+                    return Err(syn::Error::new(
+                        field.ty.span(),
+                        "cannot combine zerocopy field with other decorators"
+                    ))
+                }
+                (_, Some(SubparseSpec { on_next_layer }), length_fn, false) => {
                     finalize_chunk()?;
                     FieldState::Parsable {
                         length_fn: length_fn.clone(),
                         on_next_layer: *on_next_layer,
                     }
                 }
-                (_, Some(length_fn), false) => {
+                (_, _, Some(length_fn), false) => {
                     finalize_chunk()?;
                     FieldState::VarWidth { length_fn: length_fn.clone() }
                 }
-                (None, None, next_layer) => {
+                (_, None, None, next_layer) => {
                     let underlying_ty =
                         if let Some(ty) = &field.is { ty } else { &field.ty }
                             .clone();
                     let analysis = FixedWidthAnalysis::from_ty(&underlying_ty)?;
                     let n_bits = analysis.cached_bits;
 
-                    let mut ccb_ref = curr_chunk_bits.borrow_mut();
-                    let (curr_chunk_bits, curr_chunk_fields) =
-                        ccb_ref.get_or_insert((0, vec![]));
-                    let first_bit_in_chunk = *curr_chunk_bits;
-                    *curr_chunk_bits += analysis.cached_bits;
+                    let mut ccs_ref = curr_chunk_size.borrow_mut();
+                    let (curr_chunk_size, curr_chunk_fields) =
+                        ccs_ref.get_or_insert((ChunkSizeBits::default(), vec![]));
+                    let first_bit_in_chunk = curr_chunk_size.bits;
+                    curr_chunk_size.bits += analysis.cached_bits;
                     curr_chunk_fields.push(field_ident.clone());
 
                     if analysis.ty.is_aggregate()
-                        && (*curr_chunk_bits % 8 != 0 || n_bits % 8 != 0)
+                        && (curr_chunk_size.bits % 8 != 0 || n_bits % 8 != 0)
                     {
                         return Err(Error::new(
                             underlying_ty.span(),
@@ -789,7 +857,8 @@ impl StructParseDeriveCtx {
             FieldState::FixedWidth { bitfield_info: Some(_), .. } => {
                 quote! {#field_ident()}
             }
-            FieldState::FixedWidth { bitfield_info: None, .. } => {
+            FieldState::FixedWidth { bitfield_info: None, .. }
+            | FieldState::Zerocopy => {
                 quote! {#field_ident}
             }
             FieldState::VarWidth { .. } | FieldState::Parsable { .. } => {
@@ -862,17 +931,46 @@ impl StructParseDeriveCtx {
     pub fn gen_header_impls(&self) -> TokenStream {
         let ident = &self.ident;
         let validated_ident = self.validated_ident();
-        let base_bytes: usize = self
+        enum Size {
+            Bytes(usize),
+            Type(Type),
+        }
+        let base_size: ChunkSize = self
             .chunk_layout
             .iter()
-            .map(|v| match v {
-                ChunkState::FixedWidth { size_bytes, .. } => *size_bytes,
-                ChunkState::VarWidth(_) => 0,
+            .filter_map(|v| match v {
+                ChunkState::FixedWidth { size, .. } => Some(size),
+                ChunkState::VarWidth(_) => None,
                 // NOTE: we should/can also include <ty>::MINIMUM_LENGTH here,
                 //       since that will stll be a constexpr.
-                ChunkState::Parsable(_) => 0,
+                ChunkState::Parsable(_) => None,
             })
-            .sum();
+            .flat_map(|size| {
+                std::iter::once(Size::Bytes(size.bytes))
+                    .chain(size.zc_fields.iter().map(|z| Size::Type(z.clone())))
+            })
+            .fold(
+                ChunkSize { bytes: 0, zc_fields: vec![] },
+                |mut acc: ChunkSize, c| {
+                    match c {
+                        Size::Bytes(b) => acc.bytes += b,
+                        Size::Type(t) => acc.zc_fields.push(t),
+                    }
+                    acc
+                },
+            );
+
+        let zc_field_sizes = base_size.zc_fields.iter().map(|ty| {
+            quote! {
+                core::mem::size_of::<#ty>()
+            }
+        });
+        let bytes = base_size.bytes;
+        let base_bytes = if base_size.zc_fields.is_empty() {
+            quote! { #bytes }
+        } else {
+            quote! { #bytes + #(#zc_field_sizes)+* }
+        };
 
         let mut zc_len_checks = vec![quote! {Self::MINIMUM_LENGTH}];
         let mut owned_len_checks = zc_len_checks.clone();
@@ -1081,6 +1179,58 @@ impl StructParseDeriveCtx {
                         });
                     }
                 }
+                FieldState::Zerocopy => {
+                    direct_trait_impls.push(quote! {
+                        #[inline]
+                        fn #get_name(&self) -> #user_ty {
+                            self.#ident
+                        }
+                    });
+                    direct_trait_mut_impls.push(quote! {
+                        #[inline]
+                        fn #mut_name(&mut self, val: #user_ty) {
+                            self.#ident = val;
+                        }
+                    });
+
+                    trait_impls.push(quote! {
+                        #[inline]
+                        fn #get_name(&self) -> #user_ty {
+                            self.#sub_field_idx.#ident
+                        }
+                    });
+                    trait_mut_impls.push(quote! {
+                        #[inline]
+                        fn #mut_name(&mut self, val: #user_ty) {
+                            self.#sub_field_idx.#ident = val;
+                        }
+                    });
+
+                    direct_trait_impls.push(quote! {
+                        #[inline]
+                        fn #field_ref(&self) -> &#user_ty {
+                            &self.#ident
+                        }
+                    });
+                    trait_impls.push(quote! {
+                        #[inline]
+                        fn #field_ref(&self) -> &#user_ty {
+                            &self.#sub_field_idx.#ident
+                        }
+                    });
+                    trait_mut_impls.push(quote! {
+                        #[inline]
+                        fn #field_mut(&mut self) -> &mut #user_ty {
+                            &mut self.#sub_field_idx.#ident
+                        }
+                    });
+                    direct_trait_mut_impls.push(quote! {
+                        #[inline]
+                        fn #field_mut(&mut self) -> &mut #user_ty {
+                            &mut self.#ident
+                        }
+                    });
+                }
                 // Note: this case is predicated on the fact that we cannot
                 // move copy these types: they may be owned, or borrowed.
                 FieldState::VarWidth { .. } | FieldState::Parsable { .. } => {
@@ -1218,6 +1368,21 @@ impl StructParseDeriveCtx {
                         });
                     }
                 }
+                FieldState::Zerocopy => {
+                    trait_defs.push(quote! {
+                        fn #get_name(&self) -> #user_ty;
+                    });
+                    mut_trait_defs.push(quote! {
+                        fn #mut_name(&mut self, val: #user_ty);
+                    });
+
+                    trait_defs.push(quote! {
+                        fn #field_ref(&self) -> &#user_ty;
+                    });
+                    mut_trait_defs.push(quote! {
+                        fn #field_mut(&mut self) -> &mut #user_ty;
+                    });
+                }
                 // Note: this case is predicated on the fact that we cannot
                 // move copy these types: they may be owned, or borrowed.
                 FieldState::VarWidth { .. } | FieldState::Parsable { .. } => {
@@ -1340,6 +1505,45 @@ impl StructParseDeriveCtx {
                             }
                         });
                     }
+                }
+                FieldState::Zerocopy => {
+                    packet_impls.push(quote! {
+                        #[inline]
+                        fn #ident(&self) -> #user_ty {
+                            match self {
+                                Self::Repr(o) => o.#ident(),
+                                Self::Raw(b) => b.#ident(),
+                            }
+                        }
+                    });
+                    packet_mut_impls.push(quote! {
+                        #[inline]
+                        fn #mut_name(&mut self, val: #user_ty) {
+                            match self {
+                                Self::Repr(o) => o.#mut_name(val),
+                                Self::Raw(b) => b.#mut_name(val),
+                            };
+                        }
+                    });
+
+                    packet_impls.push(quote! {
+                        #[inline]
+                        fn #field_ref(&self) -> &#user_ty {
+                            match self {
+                                Self::Repr(o) => o.#field_ref(),
+                                Self::Raw(b) => b.#field_ref(),
+                            }
+                        }
+                    });
+                    packet_mut_impls.push(quote! {
+                        #[inline]
+                        fn #field_mut(&mut self) -> &mut #user_ty {
+                            match self {
+                                Self::Repr(o) => o.#field_mut(),
+                                Self::Raw(b) => b.#field_mut(),
+                            }
+                        }
+                    });
                 }
                 // Note: this case is predicated on the fact that we cannot
                 // move copy these types: they may be owned, or borrowed.
@@ -1624,7 +1828,7 @@ impl StructParseDeriveCtx {
             let field = field.borrow();
             let f_ident = field.ident.clone();
             match &field.state {
-                FieldState::FixedWidth { .. } => {
+                FieldState::FixedWidth { .. } | FieldState::Zerocopy => {
                     field_create.push(quote! {
                         let #f_ident = val.#f_ident();
                     });
@@ -1750,6 +1954,11 @@ impl StructParseDeriveCtx {
                                         }
                                     }
                                 },
+                                FieldState::Zerocopy => {
+                                    quote! {
+                                        g.#id = self.#id;
+                                    }
+                                }
                                 _ => unreachable!(),
                             }
                         }).collect::<Vec<_>>();

--- a/ingot-macros/src/packet/mod.rs
+++ b/ingot-macros/src/packet/mod.rs
@@ -941,7 +941,7 @@ impl StructParseDeriveCtx {
         let zc_field_sizes = base_size
             .zc_fields
             .iter()
-            .map(|(ty, n)| quote! { core::mem::size_of::<#ty>() * #n })
+            .map(|(ty, n)| quote! { ::core::mem::size_of::<#ty>() * #n })
             .chain(std::iter::once(quote! { #base_size_bytes }));
         let base_bytes = quote! { #(#zc_field_sizes)+* };
 

--- a/ingot-types/src/ip.rs
+++ b/ingot-types/src/ip.rs
@@ -7,7 +7,6 @@
 //! These addresses can be translated into [`core::net`] addresses at no cost,
 //! but they also implement traits from [`zerocopy`] for zero-copy parsing.
 
-use crate::NetworkRepr;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 /// An IPv4 address.
@@ -65,18 +64,6 @@ impl From<Ipv4Addr> for core::net::Ipv4Addr {
     #[inline]
     fn from(ip4: Ipv4Addr) -> Self {
         Self::from(ip4.inner)
-    }
-}
-
-impl NetworkRepr<[u8; 4]> for Ipv4Addr {
-    #[inline]
-    fn to_network(self) -> [u8; 4] {
-        self.octets()
-    }
-
-    #[inline]
-    fn from_network(val: [u8; 4]) -> Self {
-        Ipv4Addr::from_octets(val)
     }
 }
 
@@ -158,17 +145,5 @@ impl From<Ipv6Addr> for core::net::Ipv6Addr {
 impl From<[u8; 16]> for Ipv6Addr {
     fn from(bytes: [u8; 16]) -> Self {
         Self { inner: bytes }
-    }
-}
-
-impl NetworkRepr<[u8; 16]> for Ipv6Addr {
-    #[inline]
-    fn to_network(self) -> [u8; 16] {
-        self.octets()
-    }
-
-    #[inline]
-    fn from_network(val: [u8; 16]) -> Self {
-        Ipv6Addr::from_octets(val)
     }
 }

--- a/ingot-types/src/ip.rs
+++ b/ingot-types/src/ip.rs
@@ -1,0 +1,175 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Minimal types for IPv4 and IPv6 addresses
+//!
+//! These addresses can be translated into [`core::net`] addresses at no cost,
+//! but implement [`FromBytes`](zerocopy::FromBytes) and
+//! [`IntoBytes`](zerocopy::IntoBytes).
+
+use crate::NetworkRepr;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+/// An IPv4 address.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+)]
+#[repr(C)]
+pub struct Ipv4Addr {
+    inner: [u8; 4],
+}
+
+impl Ipv4Addr {
+    /// An IPv4 address representing an unspecified address: `0.0.0.0`
+    pub const UNSPECIFIED: Self = Self { inner: [0; 4] };
+
+    /// Return the bytes of the address.
+    #[inline]
+    pub fn octets(&self) -> [u8; 4] {
+        self.inner
+    }
+
+    /// Builds a new address from bytes
+    #[inline]
+    pub const fn from_octets(bytes: [u8; 4]) -> Self {
+        Self { inner: bytes }
+    }
+}
+
+impl From<[u8; 4]> for Ipv4Addr {
+    fn from(bytes: [u8; 4]) -> Self {
+        Self { inner: bytes }
+    }
+}
+
+impl From<core::net::Ipv4Addr> for Ipv4Addr {
+    #[inline]
+    fn from(ip4: core::net::Ipv4Addr) -> Self {
+        Self { inner: ip4.octets() }
+    }
+}
+
+impl From<Ipv4Addr> for core::net::Ipv4Addr {
+    #[inline]
+    fn from(ip4: Ipv4Addr) -> Self {
+        Self::from(ip4.inner)
+    }
+}
+
+impl NetworkRepr<[u8; 4]> for Ipv4Addr {
+    #[inline]
+    fn to_network(self) -> [u8; 4] {
+        self.octets()
+    }
+
+    #[inline]
+    fn from_network(val: [u8; 4]) -> Self {
+        Ipv4Addr::from_octets(val)
+    }
+}
+
+/// An IPv6 address.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    FromBytes,
+    IntoBytes,
+    KnownLayout,
+    Immutable,
+)]
+#[repr(C)]
+pub struct Ipv6Addr {
+    inner: [u8; 16],
+}
+
+impl Ipv6Addr {
+    /// The unspecified IPv6 address, i.e., `::` or all zeros.
+    pub const UNSPECIFIED: Self = Self { inner: [0; 16] };
+
+    /// An IPv6 address representing localhost `::1`
+    pub const LOCALHOST: Self =
+        Self { inner: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1] };
+
+    /// Return the bytes of the address.
+    #[inline]
+    pub fn octets(&self) -> [u8; 16] {
+        self.inner
+    }
+
+    /// Creates an `Ipv6Addr` from a sixteen element byte array.
+    #[inline]
+    pub const fn from_octets(bytes: [u8; 16]) -> Self {
+        Self { inner: bytes }
+    }
+
+    /// Creates an `Ipv6Addr` from an eight element 16-bit array.
+    #[inline]
+    pub const fn from_segments(words: [u16; 8]) -> Self {
+        let w0 = words[0].to_be_bytes();
+        let w1 = words[1].to_be_bytes();
+        let w2 = words[2].to_be_bytes();
+        let w3 = words[3].to_be_bytes();
+        let w4 = words[4].to_be_bytes();
+        let w5 = words[5].to_be_bytes();
+        let w6 = words[6].to_be_bytes();
+        let w7 = words[7].to_be_bytes();
+        Self {
+            inner: [
+                w0[0], w0[1], w1[0], w1[1], w2[0], w2[1], w3[0], w3[1], w4[0],
+                w4[1], w5[0], w5[1], w6[0], w6[1], w7[0], w7[1],
+            ],
+        }
+    }
+}
+
+impl From<core::net::Ipv6Addr> for Ipv6Addr {
+    #[inline]
+    fn from(ip6: core::net::Ipv6Addr) -> Self {
+        Self { inner: ip6.octets() }
+    }
+}
+
+impl From<Ipv6Addr> for core::net::Ipv6Addr {
+    #[inline]
+    fn from(ip6: Ipv6Addr) -> Self {
+        Self::from(ip6.inner)
+    }
+}
+
+impl From<[u8; 16]> for Ipv6Addr {
+    fn from(bytes: [u8; 16]) -> Self {
+        Self { inner: bytes }
+    }
+}
+
+impl NetworkRepr<[u8; 16]> for Ipv6Addr {
+    #[inline]
+    fn to_network(self) -> [u8; 16] {
+        self.octets()
+    }
+
+    #[inline]
+    fn from_network(val: [u8; 16]) -> Self {
+        Ipv6Addr::from_octets(val)
+    }
+}

--- a/ingot-types/src/ip.rs
+++ b/ingot-types/src/ip.rs
@@ -5,8 +5,7 @@
 //! Minimal types for IPv4 and IPv6 addresses
 //!
 //! These addresses can be translated into [`core::net`] addresses at no cost,
-//! but implement [`FromBytes`](zerocopy::FromBytes) and
-//! [`IntoBytes`](zerocopy::IntoBytes).
+//! but they also implement traits from [`zerocopy`] for zero-copy parsing.
 
 use crate::NetworkRepr;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};

--- a/ingot-types/src/lib.rs
+++ b/ingot-types/src/lib.rs
@@ -13,7 +13,6 @@ pub use alloc::vec::Vec;
 use core::{
     marker::PhantomData,
     mem::MaybeUninit,
-    net::{Ipv4Addr, Ipv6Addr},
     ops::{Deref, DerefMut},
 };
 use zerocopy::{
@@ -32,6 +31,7 @@ mod emit;
 mod error;
 pub mod field;
 pub mod header;
+pub mod ip;
 pub mod primitives;
 pub mod util;
 
@@ -44,6 +44,7 @@ pub use emit::*;
 pub use error::*;
 pub use field::*;
 pub use header::*;
+pub use ip::*;
 
 /// Converts a borrowed view of a header into an owned version, possibly
 /// reparsing to do so.
@@ -277,30 +278,6 @@ pub trait NetworkRepr<U: Copy> {
     fn to_network(self) -> U;
     /// Converts a raw value into a local type.
     fn from_network(val: U) -> Self;
-}
-
-impl NetworkRepr<[u8; 4]> for Ipv4Addr {
-    #[inline]
-    fn to_network(self) -> [u8; 4] {
-        self.octets()
-    }
-
-    #[inline]
-    fn from_network(val: [u8; 4]) -> Self {
-        Ipv4Addr::from(val)
-    }
-}
-
-impl NetworkRepr<[u8; 16]> for Ipv6Addr {
-    #[inline]
-    fn to_network(self) -> [u8; 16] {
-        self.octets()
-    }
-
-    #[inline]
-    fn from_network(val: [u8; 16]) -> Self {
-        Ipv6Addr::from(val)
-    }
 }
 
 impl NetworkRepr<[u8; 6]> for macaddr::MacAddr6 {

--- a/ingot/src/ip.rs
+++ b/ingot/src/ip.rs
@@ -185,9 +185,9 @@ pub struct Ipv6 {
     #[ingot(default = 128)]
     pub hop_limit: u8,
 
-    #[ingot(is = "[u8; 16]", default = Ipv6Addr::UNSPECIFIED)]
+    #[ingot(zerocopy, default = Ipv6Addr::UNSPECIFIED)]
     pub source: Ipv6Addr,
-    #[ingot(is = "[u8; 16]", default = Ipv6Addr::UNSPECIFIED)]
+    #[ingot(zerocopy, default = Ipv6Addr::UNSPECIFIED)]
     pub destination: Ipv6Addr,
 
     #[ingot(subparse(on_next_layer))]

--- a/ingot/src/ip.rs
+++ b/ingot/src/ip.rs
@@ -3,10 +3,10 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use bitflags::bitflags;
-use core::net::{Ipv4Addr, Ipv6Addr};
 use ingot_macros::{choice, Ingot};
 use ingot_types::{
-    primitives::*, util::Repeated, NetworkRepr, ParseError, Vec,
+    primitives::*, util::Repeated, Ipv4Addr, Ipv6Addr, NetworkRepr, ParseError,
+    Vec,
 };
 
 #[derive(Clone, Copy, Hash, Debug, PartialEq, Eq, Ord, PartialOrd)]

--- a/ingot/src/ip.rs
+++ b/ingot/src/ip.rs
@@ -96,9 +96,9 @@ pub struct Ipv4 {
     pub protocol: IpProtocol,
     pub checksum: u16be,
 
-    #[ingot(is = "[u8; 4]", default = Ipv4Addr::UNSPECIFIED)]
+    #[ingot(zerocopy, default = Ipv4Addr::UNSPECIFIED)]
     pub source: Ipv4Addr,
-    #[ingot(is = "[u8; 4]", default = Ipv4Addr::UNSPECIFIED)]
+    #[ingot(zerocopy, default = Ipv4Addr::UNSPECIFIED)]
     pub destination: Ipv4Addr,
 
     #[ingot(var_len = "(ihl * 4).saturating_sub(20)")]

--- a/ingot/src/tests.rs
+++ b/ingot/src/tests.rs
@@ -14,13 +14,13 @@ use crate::{
     },
     types::{
         primitives::*, util::RepeatedView, Accessor, Emit, HeaderLen,
-        HeaderParse, NetworkRepr, NextLayer, NextLayerChoice, ParseChoice,
-        ParseError, ToOwnedPacket,
+        HeaderParse, Ipv6Addr, NetworkRepr, NextLayer, NextLayerChoice,
+        ParseChoice, ParseError, ToOwnedPacket,
     },
     udp::{Udp, UdpRef, ValidUdp, _Udp_ingot_impl::UdpPart0},
     Ingot,
 };
-use core::{mem, net::Ipv6Addr};
+use core::mem;
 use macaddr::MacAddr6;
 use zerocopy::IntoBytes;
 


### PR DESCRIPTION
- Add new `zerocopy` decorator to `ingot` fields, which mark fields that can read / written directly as bytes
- Add `Ipv4Addr` and `Ipv6Addr` to `ingot_types`
- Use these new types in `ingot` packet headers

This is a little tricky, because we lose explicit tracking of size during macro evaluation!  Instead, size becomes a known number of bits, plus some number of zerocopy fields.  We can still compute size at compile time with a `const` expression (using `size_of`).  The zerocopy fields are guaranteed to be byte-aligned, so if we are byte-aligned when they start, we remain byte-aligned afterwards.