### PR TITLE
Add support for zerocopy `Vec<T>` and IGMP packets

### DIFF
--- a/ingot-macros/src/lib.rs
+++ b/ingot-macros/src/lib.rs
@@ -126,6 +126,12 @@ pub fn derive_parse(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// * `#[ingot(var_len = "<expr>")]` – Determines the length of a `Vec<u8>` field,
 ///   or provides an exact length for a variable-length subparse. This expression
 ///   can access any prior fixed-width field.
+/// * `#[ingot(var_len = "<expr>", zerocopy)]` – Determines the length of a
+///   `Vec<T>` field, where `T` obeys the `zerocopy` guidelines above and
+///   implements `HeaderLen`, `Emit`, and `HasView` from `ingot::types`.  (To
+///   automatically implement those traits, see the
+///   `ingot::types::zerocopy_type!` macro.) The `var_len` expression can access
+///   any prior fixed-width field, and is a length in _items_ (not bytes).
 #[proc_macro_derive(Ingot, attributes(ingot))]
 pub fn derive_ingot(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let d_input = parse_macro_input!(input);

--- a/ingot-types/src/field.rs
+++ b/ingot-types/src/field.rs
@@ -16,11 +16,11 @@ pub enum FieldRef<'a, T: HasView<V>, V> {
     Raw(&'a HeaderOf<T, V>),
 }
 
-impl<T: HasView<V, ViewType = Q> + AsRef<[u8]>, V, Q: AsRef<[u8]>> AsRef<[u8]>
+impl<Z, T: HasView<V, ViewType = Q> + AsRef<[Z]>, V, Q: AsRef<[Z]>> AsRef<[Z]>
     for FieldRef<'_, T, V>
 {
     #[inline]
-    fn as_ref(&self) -> &[u8] {
+    fn as_ref(&self) -> &[Z] {
         match self {
             FieldRef::Repr(t) => t.as_ref(),
             FieldRef::Raw(Header::Repr(a)) => a.deref().as_ref(),

--- a/ingot-types/src/header.rs
+++ b/ingot-types/src/header.rs
@@ -133,11 +133,16 @@ impl<
 }
 
 #[cfg(feature = "alloc")]
-impl<B: ByteSlice> From<&BoxedHeader<Vec<u8>, RawBytes<B>>> for Vec<u8> {
-    fn from(value: &Header<Vec<u8>, RawBytes<B>>) -> Self {
+impl<B: ByteSlice, T> From<&BoxedHeader<Vec<T>, RawBytes<B>>> for Vec<T>
+where
+    T: FromBytes + IntoBytes + KnownLayout + Immutable + Clone,
+{
+    fn from(value: &Header<Vec<T>, RawBytes<B>>) -> Self {
         match value {
-            Header::Repr(v) => v.to_vec(),
-            Header::Raw(v) => v.to_vec(),
+            Header::Repr(v) => v.deref().clone(),
+            Header::Raw(v) => {
+                <[T]>::ref_from_bytes(v.as_ref()).unwrap().to_vec()
+            }
         }
     }
 }

--- a/ingot-types/src/ip.rs
+++ b/ingot-types/src/ip.rs
@@ -7,6 +7,7 @@
 //! These addresses can be translated into [`core::net`] addresses at no cost,
 //! but they also implement traits from [`zerocopy`] for zero-copy parsing.
 
+use crate::zerocopy_type;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 /// An IPv4 address.
@@ -66,6 +67,8 @@ impl From<Ipv4Addr> for core::net::Ipv4Addr {
         Self::from(ip4.inner)
     }
 }
+
+zerocopy_type!(Ipv4Addr);
 
 /// An IPv6 address.
 #[derive(
@@ -147,3 +150,5 @@ impl From<[u8; 16]> for Ipv6Addr {
         Self { inner: bytes }
     }
 }
+
+zerocopy_type!(Ipv6Addr);

--- a/ingot-types/src/primitives.rs
+++ b/ingot-types/src/primitives.rs
@@ -45,7 +45,13 @@ pub type VarBytes<V> = Header<Vec<u8>, V>;
 /// Buffer type which can be owned or a view.
 pub type VarBytes<V> = Header<Vec<u8, 256>, V>;
 
-impl<B: ByteSlice> HasView<B> for Vec<u8> {
+impl<B: ByteSlice, T> HasView<B> for Vec<T>
+where
+    T: zerocopy::FromBytes
+        + zerocopy::IntoBytes
+        + zerocopy::KnownLayout
+        + zerocopy::Immutable,
+{
     type ViewType = RawBytes<B>;
 }
 

--- a/ingot-types/src/util.rs
+++ b/ingot-types/src/util.rs
@@ -367,8 +367,11 @@ macro_rules! zerocopy_type {
                 false
             }
         }
-        impl<B: zerocopy::ByteSlice> $crate::HasView<B> for $t {
-            type ViewType = $crate::primitives::RawBytes<B>;
+        impl<B: zerocopy::ByteSlice>
+            $crate::HasView<$crate::primitives::ObjectSlice<B, $t>>
+            for ::alloc::vec::Vec<$t>
+        {
+            type ViewType = $crate::primitives::ObjectSlice<B, $t>;
         }
     };
 }

--- a/ingot-types/src/util.rs
+++ b/ingot-types/src/util.rs
@@ -339,3 +339,36 @@ where
         self.iter(hint).last().and_then(|v| v.ok()).and_then(|v| v.next_layer())
     }
 }
+
+/// Macro which defines `HeaderLen`, `Emit`, and `HasView` for a type
+///
+/// These are necessary for the type to be used in a variable-length field.
+#[macro_export]
+macro_rules! zerocopy_type {
+    ($t:ty) => {
+        impl $crate::HeaderLen for $t {
+            const MINIMUM_LENGTH: usize = core::mem::size_of::<Self>();
+            #[inline]
+            fn packet_length(&self) -> usize {
+                Self::MINIMUM_LENGTH
+            }
+        }
+
+        impl $crate::Emit for $t {
+            #[inline]
+            fn emit_raw<V: zerocopy::ByteSliceMut>(&self, mut buf: V) -> usize {
+                use zerocopy::IntoBytes;
+                let len = core::mem::size_of::<Self>();
+                buf[..len].copy_from_slice(self.as_bytes());
+                len
+            }
+            #[inline]
+            fn needs_emit(&self) -> bool {
+                false
+            }
+        }
+        impl<B: zerocopy::ByteSlice> $crate::HasView<B> for $t {
+            type ViewType = $crate::primitives::RawBytes<B>;
+        }
+    };
+}

--- a/ingot/src/igmp.rs
+++ b/ingot/src/igmp.rs
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use ingot_macros::Ingot;
+use ingot_types::{primitives::*, util::Repeated, Ipv4Addr, NetworkRepr, Vec};
+
+/// See RFC3376, §4.1
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Ingot)]
+#[ingot(impl_default)]
+pub struct IgmpMembershipQuery {
+    #[ingot(default = 0x11)]
+    pub ty: u8,
+    pub max_resp: u8,
+    pub checksum: u16be,
+    #[ingot(zerocopy, default = Ipv4Addr::UNSPECIFIED)]
+    pub group_address: Ipv4Addr,
+    resv: u4, // padding
+
+    pub s: u1,
+    pub qrv: u3,
+    pub qqic: u8,
+    pub num_sources: u16be,
+
+    #[ingot(zerocopy, var_len = "num_sources.get()")]
+    pub source_addrs: Vec<Ipv4Addr>,
+    // XXX the RFC specifies that additional data may be present and should be
+    // used in the checksum; how do we parse that?
+}
+
+/// See RFC3376, §4.2
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Ingot)]
+#[ingot(impl_default)]
+pub struct IgmpV3MembershipReport {
+    #[ingot(default = 0x22)]
+    pub ty: u8,
+    resv1: u8,
+    pub checksum: u16be,
+    resv2: u16be,
+    pub num_group_records: u16be,
+    #[ingot(subparse())]
+    pub group_records: Repeated<IgmpV3GroupRecord>,
+}
+
+/// See RFC3376, §4.2.12
+#[derive(Clone, Copy, Hash, Debug, PartialEq, Eq, Ord, PartialOrd)]
+pub struct IgmpV3RecordType(pub u8);
+
+impl IgmpV3RecordType {
+    pub const MODE_IS_INCLUDE: Self = Self(1);
+    pub const MODE_IS_EXCLUDE: Self = Self(2);
+    pub const CHANGE_TO_INCLUDE_MODE: Self = Self(3);
+    pub const CHANGE_TO_EXCLUDE_MODE: Self = Self(4);
+}
+
+impl NetworkRepr<u8> for IgmpV3RecordType {
+    #[inline]
+    fn to_network(self) -> u8 {
+        self.0
+    }
+
+    #[inline]
+    fn from_network(val: u8) -> Self {
+        Self(val)
+    }
+}
+
+/// See RFC3376, §4.2
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Ingot)]
+pub struct IgmpV3GroupRecord {
+    #[ingot(is = "u8")]
+    pub record_type: IgmpV3RecordType,
+    pub aux_data_len: u8,
+    pub num_sources: u16be,
+    #[ingot(zerocopy)]
+    pub multicast_addr: Ipv4Addr,
+
+    #[ingot(zerocopy, var_len = "num_sources.get()")]
+    pub source_addrs: Vec<Ipv4Addr>,
+    #[ingot(var_len = "aux_data_len")]
+    pub auxiliary_data: Vec<u8>,
+}
+
+/// See RFC2236, §2
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Ingot)]
+#[ingot(impl_default)]
+pub struct IgmpV2MembershipReport {
+    #[ingot(default = 0x16)]
+    pub ty: u8,
+    pub max_resp: u8,
+    pub checksum: u16be,
+    #[ingot(zerocopy, default = Ipv4Addr::UNSPECIFIED)]
+    pub group_address: Ipv4Addr,
+}
+
+/// See RFC2236, §2
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Ingot)]
+#[ingot(impl_default)]
+pub struct IgmpV2LeaveGroup {
+    #[ingot(default = 0x17)]
+    pub ty: u8,
+    pub max_resp: u8,
+    pub checksum: u16be,
+    #[ingot(zerocopy, default = Ipv4Addr::UNSPECIFIED)]
+    pub group_address: Ipv4Addr,
+}
+// XXX should these be the same type with a strong type for `ty`?

--- a/ingot/src/igmp.rs
+++ b/ingot/src/igmp.rs
@@ -49,8 +49,8 @@ pub struct IgmpMembershipQuery {
 
     #[ingot(zerocopy, var_len = "num_sources.get()")]
     pub source_addrs: Vec<Ipv4Addr>,
-    // XXX the RFC specifies that additional data may be present and should be
-    // used in the checksum; how do we parse that?
+    // There may be additional trailing data in the packet, which should be used
+    // when computing the checksum.
 }
 
 /// See RFC3376, §4.2
@@ -65,9 +65,8 @@ pub struct IgmpV3MembershipReport {
     pub num_group_records: u16be, // not used, we just read the remaining data
     #[ingot(subparse())]
     pub group_records: Repeated<IgmpV3GroupRecord>,
-    // XXX the RFC specifies that additional data may be present and should be
-    // used in the checksum, but we're assuming that group records are the rest
-    // of the packet (because their size isn't fully specified)
+    // There may be additional trailing data in the packet, which should be used
+    // when computing the checksum.
 }
 
 /// See RFC3376, §4.2.12
@@ -132,4 +131,126 @@ pub struct IgmpV2LeaveGroup {
     #[ingot(zerocopy, default = Ipv4Addr::UNSPECIFIED)]
     pub group_address: Ipv4Addr,
 }
-// XXX should these be the same type, since they only differ in `ty`?
+
+#[cfg(test)]
+#[allow(clippy::unusual_byte_groupings)]
+mod test {
+    use super::*;
+    use crate::types::{Header, HeaderParse};
+
+    #[test]
+    fn parse() {
+        #[rustfmt::skip]
+        let bytes: &[u8] = &[
+            0x11,
+            0x00,
+            0x00, 0x00,
+            1, 4, 6, 8,
+            0b0000_0_010, 64,
+            0x00, 0x05,
+
+            2, 2, 2, 2,
+            2, 2, 2, 3,
+            2, 2, 2, 4,
+            2, 2, 2, 5,
+            2, 2, 2, 6,
+        ][..];
+        let (igmp, ..) = ValidIgmpMembershipQuery::parse(bytes).unwrap();
+        assert_eq!(igmp.ty(), IgmpMessageType::MEMBERSHIP_QUERY);
+        assert_eq!(igmp.max_resp(), 0);
+        assert_eq!(igmp.checksum(), 0);
+        assert_eq!(igmp.group_address(), Ipv4Addr::from_octets([1, 4, 6, 8]));
+        assert_eq!(igmp.qrv(), 0b10);
+        assert_eq!(igmp.qqic(), 64);
+        assert_eq!(igmp.num_sources(), 5);
+
+        match igmp.source_addrs_ref() {
+            ingot_types::FieldRef::Repr(_a) => todo!("owned"),
+            ingot_types::FieldRef::Raw(Header::Repr(_a)) => todo!("also owned"),
+            ingot_types::FieldRef::Raw(Header::Raw(ips)) => {
+                assert_eq!(ips.len(), 5);
+                assert_eq!(ips[0], Ipv4Addr::from_octets([2, 2, 2, 2]));
+                assert_eq!(ips[1], Ipv4Addr::from_octets([2, 2, 2, 3]));
+                assert_eq!(ips[2], Ipv4Addr::from_octets([2, 2, 2, 4]));
+                assert_eq!(ips[3], Ipv4Addr::from_octets([2, 2, 2, 5]));
+                assert_eq!(ips[4], Ipv4Addr::from_octets([2, 2, 2, 6]));
+            }
+        }
+    }
+
+    #[test]
+    fn parse_mut() {
+        #[rustfmt::skip]
+        let bytes: &mut [u8] = &mut [
+            0x11,
+            0x00,
+            0x00, 0x00,
+            1, 4, 6, 8,
+            0b0000_0_010, 64,
+            0x00, 0x05,
+
+            2, 2, 2, 2,
+            2, 2, 2, 3,
+            2, 2, 2, 4,
+            2, 2, 2, 5,
+            2, 2, 2, 6,
+        ][..];
+        let (mut igmp, ..) =
+            ValidIgmpMembershipQuery::parse(&mut bytes[..]).unwrap();
+
+        match igmp.source_addrs_mut() {
+            ingot_types::FieldMut::Repr(_a) => todo!("owned"),
+            ingot_types::FieldMut::Raw(Header::Repr(_a)) => todo!("also owned"),
+            ingot_types::FieldMut::Raw(Header::Raw(ips)) => {
+                assert_eq!(ips.len(), 5);
+                assert_eq!(ips[0], Ipv4Addr::from_octets([2, 2, 2, 2]));
+                assert_eq!(ips[1], Ipv4Addr::from_octets([2, 2, 2, 3]));
+                assert_eq!(ips[2], Ipv4Addr::from_octets([2, 2, 2, 4]));
+                assert_eq!(ips[3], Ipv4Addr::from_octets([2, 2, 2, 5]));
+                assert_eq!(ips[4], Ipv4Addr::from_octets([2, 2, 2, 6]));
+                ips[0] = Ipv4Addr::from_octets([4, 5, 6, 7]);
+            }
+        }
+        assert_eq!(&bytes[12..16], [4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn not_enough_ips() {
+        #[rustfmt::skip]
+        let bytes: &[u8] = &[
+            0x11,
+            0x00,
+            0x00, 0x00,
+            1, 4, 6, 8,
+            0b0000_0_010, 64,
+            0x00, 0x05,
+
+            2, 2, 2, 2,
+            2, 2, 2, 3,
+            2, 2, 2, 4,
+            2, 2, 2, 5,
+        ][..];
+        let r = ValidIgmpMembershipQuery::parse(bytes);
+        assert!(matches!(r, Err(ingot::types::ParseError::TooSmall)));
+    }
+
+    #[test]
+    fn extra_payload() {
+        #[rustfmt::skip]
+        let bytes: &[u8] = &[
+            0x11,
+            0x00,
+            0x00, 0x00,
+            1, 1, 1, 1,
+            0b0000_0_010, 64,
+            0x00, 0x03,
+
+            2, 2, 2, 2,
+            2, 2, 2, 3,
+            2, 2, 2, 4,
+            1, 2, 3, 4, 5 // bonus data
+        ][..];
+        let (_r, _, rest) = ValidIgmpMembershipQuery::parse(bytes).unwrap();
+        assert_eq!(rest, &[1, 2, 3, 4, 5]);
+    }
+}

--- a/ingot/src/lib.rs
+++ b/ingot/src/lib.rs
@@ -156,6 +156,7 @@ pub use ingot_types as types;
 pub mod ethernet;
 pub mod geneve;
 pub mod icmp;
+pub mod igmp;
 pub mod ip;
 pub mod tcp;
 pub mod udp;


### PR DESCRIPTION
This PR does two things:

- It adds support for `#[ingot(var_len = "..", zerocopy)]` fields, which are a `Vec<T>`
- It implements IGMP packets using that new primitive

The proc macro changes are a little awkward!  It requires the type `T` to implement a bunch `ingot_types` traits, as well as `zerocopy` traits.  However, it's hard to do a blanket implementation on all zerocopy-flavored types, because of trait coherence.  Instead, I added a new `zerocopy_type!` macro which does all of the trait implementations for you.

In an attempt _not_ to do this, I experimented with a newtype wrapper, e.g. `Zc<T>(T)`.  This is tricky, because then the original `struct` (which contains a `Vec<T>`) and generated `struct ValidXyz` (which contains a `Vec<Zc<T>>`) can't both return the same type.

Even if you overcome this hurdle, it seems like the original packet wants to implement `HasView`, `emit_raw`, etc, which can't be done from a `Vec<T>` without `T` also implementing those traits (I'm less sure about this part, but trying to decipher the proc-macro errors).

Anyways, I think this is a decent solution for now.  We can always change the implementation later without affecting downstream users of the proc macro.

# TODO
- [x] Add some IGMP unit tests
- [x] Answer remaining `XXX` questions