### PR TITLE
Provide type hint to fix unhinted subparse

### DIFF
--- a/ingot-macros/src/packet/mod.rs
+++ b/ingot-macros/src/packet/mod.rs
@@ -1783,7 +1783,7 @@ impl StructParseDeriveCtx {
                     use ::ingot::types::ParseChoice;
                     use ::ingot::types::HeaderParse;
 
-                    let mut hint = None;
+                    let mut hint: Option<<Self as NextLayer>::Denom> = None;
 
                     #( #segment_fragments )*
 


### PR DESCRIPTION
Fixes #15; otherwise, the `hint` field is never used and the compiler gets mad about not being able to infer its type.