### PR TITLE
Fix nested packet size

### DIFF
--- a/ingot-macros/src/packet/mod.rs
+++ b/ingot-macros/src/packet/mod.rs
@@ -982,11 +982,12 @@ impl StructParseDeriveCtx {
             let idx = syn::Index::from(i);
             match field {
                 ChunkState::VarWidth(id) | ChunkState::Parsable(id) => {
+                    let ty = &self.validated[id].borrow().user_ty;
                     zc_len_checks.push(quote! {
-                        self.#idx.packet_length()
+                        self.#idx.packet_length() - <#ty as ::ingot::types::HeaderLen>::MINIMUM_LENGTH
                     });
                     owned_len_checks.push(quote! {
-                        self.#id.packet_length()
+                        self.#id.packet_length() - <#ty as ::ingot::types::HeaderLen>::MINIMUM_LENGTH
                     });
                 }
                 ChunkState::FixedWidth { .. } => {}

--- a/ingot/src/tests.rs
+++ b/ingot/src/tests.rs
@@ -563,3 +563,33 @@ fn accessor_functions_safely() {
     a.destination = 8989.into();
     assert_eq!(u16::from(a.destination), 8989);
 }
+
+#[derive(Ingot)]
+pub struct OuterPacket {
+    pub bla: u8,
+
+    #[ingot(subparse())]
+    pub next_packet: InnerPacket,
+}
+
+#[derive(Clone, Ingot)]
+pub struct InnerPacket {
+    pub boo: u8,
+    #[ingot(var_len = "boo")]
+    pub varying: alloc::vec::Vec<u8>,
+}
+
+#[test]
+fn nested_packet_size() {
+    let p = OuterPacket {
+        bla: 1,
+        next_packet: InnerPacket { boo: 2, varying: vec![1, 2] },
+    };
+    assert_eq!(p.packet_length(), 4);
+
+    let p = OuterPacket {
+        bla: 1,
+        next_packet: InnerPacket { boo: 0, varying: vec![] },
+    };
+    assert_eq!(p.packet_length(), 2);
+}


### PR DESCRIPTION
(stacked on top of #16 )

We were previously double-counting nested packet sizes: both in the parent packet's `MINIMUM_SIZE`, and again when calling the inner `packet_size()`.  This wasn't an issue when the only nested packets were `Repeated<..>` (with a minimum size of 0), but #16 lets us nest a **single** header within another.