### PR TITLE
Fix blanket impl

### DIFF
--- a/ingot-types/src/primitives.rs
+++ b/ingot-types/src/primitives.rs
@@ -45,14 +45,12 @@ pub type VarBytes<V> = Header<Vec<u8>, V>;
 /// Buffer type which can be owned or a view.
 pub type VarBytes<V> = Header<Vec<u8, 256>, V>;
 
-impl<B: ByteSlice, T> HasView<B> for Vec<T>
-where
-    T: zerocopy::FromBytes
-        + zerocopy::IntoBytes
-        + zerocopy::KnownLayout
-        + zerocopy::Immutable,
-{
+impl<B: ByteSlice> HasView<B> for Vec<u8> {
     type ViewType = RawBytes<B>;
+}
+
+impl<B: zerocopy::ByteSlice, T> HasView<ObjectSlice<B, T>> for Vec<T> {
+    type ViewType = ObjectSlice<B, T>;
 }
 
 impl<V: ByteSlice> From<&VarBytes<V>> for Vec<u8> {

--- a/ingot-types/src/util.rs
+++ b/ingot-types/src/util.rs
@@ -367,11 +367,5 @@ macro_rules! zerocopy_type {
                 false
             }
         }
-        impl<B: zerocopy::ByteSlice>
-            $crate::HasView<$crate::primitives::ObjectSlice<B, $t>>
-            for ::alloc::vec::Vec<$t>
-        {
-            type ViewType = $crate::primitives::ObjectSlice<B, $t>;
-        }
     };
 }


### PR DESCRIPTION
Previously, `zerocopy_type!` didn't work outside of the `ingot_types` crate, because it implemented `ingot_types::HasView<ObjectSlice<B, $ty>> for Vec<$ty>`.  Outside of the `ingot_types` crate, both the trait and the type are foreign, so this is not allowed!

This PR adds a blanket `HasView` impl for all `ObjectSlice`, and remove it from the macro.  Doing so requires changing the other blanket impl back to `Vec<u8>` to avoid collisions, but that was my fault (I made it overly generic in #14).