### PR TITLE
Support `ingot(zerocopy, next_layer)`

### DIFF
--- a/ingot-examples/src/tests.rs
+++ b/ingot-examples/src/tests.rs
@@ -11,8 +11,8 @@ use ingot::{
         ValidIpv6,
     },
     types::{
-        HeaderLen, HeaderParse, Ipv4Addr, Ipv6Addr, NetworkRepr, NextLayer,
-        ParseError, Parsed, Read,
+        HeaderLen, HeaderParse, Ipv4Addr, Ipv6Addr, NextLayer, ParseError,
+        Parsed, Read,
     },
     udp::{Udp, UdpMut, UdpRef, ValidUdp},
 };
@@ -122,7 +122,7 @@ fn parse_header_chain_multichunk() {
     let mut eth_bytes = vec![0u8; Ethernet::MINIMUM_LENGTH];
     let mut v6_bytes = vec![0u8; Ipv6::MINIMUM_LENGTH];
     // 0 is a valid v6 EH -- need to init it before parse.
-    v6_bytes[6] = IpProtocol::UDP.to_network();
+    v6_bytes[6] = IpProtocol::UDP.0;
     let mut udp_bytes = vec![0u8; Udp::MINIMUM_LENGTH];
     let body_bytes = vec![0xaau8; 128];
     {

--- a/ingot-types/src/ip.rs
+++ b/ingot-types/src/ip.rs
@@ -8,28 +8,13 @@
 //! but they also implement traits from [`zerocopy`] for zero-copy parsing.
 
 use crate::zerocopy_type;
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
-/// An IPv4 address.
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Default,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    FromBytes,
-    IntoBytes,
-    KnownLayout,
-    Immutable,
-)]
-#[repr(C)]
-pub struct Ipv4Addr {
-    inner: [u8; 4],
-}
+zerocopy_type!(
+    /// An IPv4 address
+    pub struct Ipv4Addr {
+        inner: [u8; 4],
+    }
+);
 
 impl Ipv4Addr {
     /// An IPv4 address representing an unspecified address: `0.0.0.0`
@@ -48,12 +33,6 @@ impl Ipv4Addr {
     }
 }
 
-impl From<[u8; 4]> for Ipv4Addr {
-    fn from(bytes: [u8; 4]) -> Self {
-        Self { inner: bytes }
-    }
-}
-
 impl From<core::net::Ipv4Addr> for Ipv4Addr {
     #[inline]
     fn from(ip4: core::net::Ipv4Addr) -> Self {
@@ -68,28 +47,12 @@ impl From<Ipv4Addr> for core::net::Ipv4Addr {
     }
 }
 
-zerocopy_type!(Ipv4Addr);
-
-/// An IPv6 address.
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Default,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    FromBytes,
-    IntoBytes,
-    KnownLayout,
-    Immutable,
-)]
-#[repr(C)]
-pub struct Ipv6Addr {
-    inner: [u8; 16],
-}
+zerocopy_type!(
+    /// An IPv6 address.
+    pub struct Ipv6Addr {
+        inner: [u8; 16],
+    }
+);
 
 impl Ipv6Addr {
     /// The unspecified IPv6 address, i.e., `::` or all zeros.
@@ -144,11 +107,3 @@ impl From<Ipv6Addr> for core::net::Ipv6Addr {
         Self::from(ip6.inner)
     }
 }
-
-impl From<[u8; 16]> for Ipv6Addr {
-    fn from(bytes: [u8; 16]) -> Self {
-        Self { inner: bytes }
-    }
-}
-
-zerocopy_type!(Ipv6Addr);

--- a/ingot/src/geneve.rs
+++ b/ingot/src/geneve.rs
@@ -62,20 +62,12 @@ impl NetworkRepr<u8> for GeneveFlags {
     }
 }
 
-/// Indicator of the format of a Geneve option, when combined with
-/// an organisation-specific class.
-#[derive(Clone, Copy, Hash, Debug, PartialEq, Eq, Ord, PartialOrd, Default)]
-pub struct GeneveOptionType(pub u8);
-
-impl NetworkRepr<u8> for GeneveOptionType {
-    fn to_network(self) -> u8 {
-        self.0
-    }
-
-    fn from_network(val: u8) -> Self {
-        Self(val)
-    }
-}
+ingot_types::zerocopy_type!(
+    /// Indicator of the format of a Geneve option, when combined with
+    /// an organisation-specific class.
+    #[derive(Default)]
+    pub struct GeneveOptionType(pub u8)
+);
 
 impl GeneveOptionType {
     /// Denotes whether this option is 'critical': a critical packet
@@ -99,7 +91,7 @@ pub struct GeneveOpt {
     ///
     /// [`data`]: GeneveOpt::data
     /// [`class`]: GeneveOpt::class
-    #[ingot(is = "u8")]
+    #[ingot(zerocopy)]
     pub option_type: GeneveOptionType,
     /// Currently reserved bits -- these must be sent as `0`, and not
     /// validated by tunnel endpoints/forwarders.

--- a/ingot/src/ip.rs
+++ b/ingot/src/ip.rs
@@ -9,8 +9,7 @@ use ingot_types::{
     Vec,
 };
 
-#[derive(Clone, Copy, Hash, Debug, PartialEq, Eq, Ord, PartialOrd)]
-pub struct IpProtocol(pub u8);
+ingot_types::zerocopy_type!(pub struct IpProtocol(pub u8));
 
 #[derive(Clone, Copy, Hash, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub enum ExtHdrClass {
@@ -61,18 +60,6 @@ impl Default for IpProtocol {
     }
 }
 
-impl NetworkRepr<u8> for IpProtocol {
-    #[inline]
-    fn to_network(self) -> u8 {
-        self.0
-    }
-
-    #[inline]
-    fn from_network(val: u8) -> Self {
-        Self(val)
-    }
-}
-
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Ingot)]
 #[ingot(impl_default)]
 pub struct Ipv4 {
@@ -92,7 +79,7 @@ pub struct Ipv4 {
 
     #[ingot(default = 128)]
     pub hop_limit: u8,
-    #[ingot(is = "u8", next_layer)]
+    #[ingot(zerocopy, next_layer)]
     pub protocol: IpProtocol,
     pub checksum: u16be,
 
@@ -180,7 +167,7 @@ pub struct Ipv6 {
     pub flow_label: u20be,
 
     pub payload_len: u16be,
-    #[ingot(is = "u8", next_layer)]
+    #[ingot(zerocopy, next_layer)]
     pub next_header: IpProtocol,
     #[ingot(default = 128)]
     pub hop_limit: u8,
@@ -203,7 +190,7 @@ pub enum LowRentV6Eh {
 // 0x2c
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Ingot)]
 pub struct IpV6ExtFragment {
-    #[ingot(is = "u8", next_layer)]
+    #[ingot(zerocopy, next_layer)]
     pub next_header: IpProtocol, // should be a type.
     pub reserved: u8,
     pub fragment_offset: u13be,
@@ -215,7 +202,7 @@ pub struct IpV6ExtFragment {
 // 0x00, 0x2b, 0x3c, custom(0xfe)
 #[derive(Debug, Clone, Ingot, Eq, PartialEq)]
 pub struct IpV6Ext6564 {
-    #[ingot(is = "u8", next_layer)]
+    #[ingot(zerocopy, next_layer)]
     pub next_header: IpProtocol, // should be a type.
     pub ext_len: u8,
 

--- a/ingot/src/tests.rs
+++ b/ingot/src/tests.rs
@@ -14,8 +14,8 @@ use crate::{
     },
     types::{
         primitives::*, util::RepeatedView, Accessor, Emit, HeaderLen,
-        HeaderParse, Ipv6Addr, NetworkRepr, NextLayer, NextLayerChoice,
-        ParseChoice, ParseError, ToOwnedPacket,
+        HeaderParse, Ipv6Addr, NextLayer, NextLayerChoice, ParseChoice,
+        ParseError, ToOwnedPacket,
     },
     udp::{Udp, UdpRef, ValidUdp, _Udp_ingot_impl::UdpPart0},
     Ingot,
@@ -60,7 +60,7 @@ fn base_parse_and_type_conversion() {
     let (mut eth, .., rest) = ValidEthernet::parse(&mut buf2[..]).unwrap();
 
     // 0 is a valid v6 EH -- need to change to e.g. TCP before parse.
-    rest[6] = IpProtocol::TCP.to_network();
+    rest[6] = IpProtocol::TCP.0;
     let (.., rest) = ValidIpv6::parse(&mut rest[..]).unwrap();
     assert_eq!(rest.len(), 0);
     assert_eq!(eth.source(), MacAddr6::nil());


### PR DESCRIPTION
(staged on top of #20)

This lets us treat `IpProtocol` as a `zerocopy` type, instead of needing `NetworkRepr` translation functions.