### PR TITLE
Delegate `Vec`'s `emit_raw` to `&[u8]`

### DIFF
--- a/ingot-types/src/emit.rs
+++ b/ingot-types/src/emit.rs
@@ -156,10 +156,8 @@ impl Emit for &[u8] {
 
 impl Emit for Vec<u8> {
     #[inline]
-    fn emit_raw<V: ByteSliceMut>(&self, mut buf: V) -> usize {
-        buf.copy_from_slice(self);
-
-        self.len()
+    fn emit_raw<V: ByteSliceMut>(&self, buf: V) -> usize {
+        self.as_slice().emit_raw(buf)
     }
 
     #[inline]


### PR DESCRIPTION
This is a fairly simple fix for the case where we emit a packet containing a `Vec<u8>` as one of the interim header layers.

Closes #9.