### PR TITLE
Use next-layer type when delegating next_layer (1/)

### DIFF
--- a/ingot-macros/src/packet/mod.rs
+++ b/ingot-macros/src/packet/mod.rs
@@ -845,8 +845,14 @@ impl StructParseDeriveCtx {
                     &format!("{subparse_ident}_ref"),
                     subparse_ident.span(),
                 );
+                let ref_ty = &self
+                    .validated
+                    .get(&subparse_ident)
+                    .unwrap()
+                    .borrow()
+                    .user_ty;
                 (
-                    quote! {#user_ty},
+                    quote! {<#ref_ty as ::ingot::types::NextLayer>::Denom},
                     quote! {
                         use ::ingot::types::NextLayerChoice;
                         use ::ingot::types::HeaderLen;


### PR DESCRIPTION
Right now, the `next_layer` type when subparsing must always be the same as our current layer.  However, we've talked about changing this in https://github.com/oxidecomputer/ingot/pull/14#discussion_r1937053180 .  When we end up supporting heterogenous subparses, it will be more correct to return the type of the next layer; in the meantime, this doesn't break anything.