### PR TITLE
Simplify type magic (2/)

### DIFF
--- a/ingot-types/src/field.rs
+++ b/ingot-types/src/field.rs
@@ -55,13 +55,12 @@ impl<B: ByteSlice> FieldRef<'_, Vec<u8>, B> {
     }
 }
 
-impl<D, T: HasView<V, ViewType = Q> + NextLayer<Denom = D>, V, Q> NextLayer
+impl<T: HasView<V, ViewType = Q> + NextLayer, V, Q> NextLayer
     for FieldRef<'_, T, V>
 where
-    D: Copy + Eq,
-    HeaderOf<T, V>: NextLayer<Denom = D>,
+    HeaderOf<T, V>: NextLayer<Denom = T::Denom>,
 {
-    type Denom = D;
+    type Denom = T::Denom;
 
     fn next_layer(&self) -> Option<Self::Denom> {
         match self {
@@ -71,13 +70,11 @@ where
     }
 }
 
-impl<D, D2, T: HasView<V, ViewType = Q> + NextLayerChoice<D2>, V, Q>
+impl<D2, T: HasView<V, ViewType = Q> + NextLayerChoice<D2>, V, Q>
     NextLayerChoice<D2> for FieldRef<'_, T, V>
 where
-    D: Copy + Eq,
     D2: Copy + Eq,
-    HeaderOf<T, V>: NextLayer<Denom = D> + NextLayerChoice<D2>,
-    T: NextLayer<Denom = D>,
+    HeaderOf<T, V>: NextLayer<Denom = T::Denom> + NextLayerChoice<D2>,
 {
     fn next_layer_choice(&self, hint: Option<D2>) -> Option<Self::Denom> {
         match self {
@@ -138,13 +135,12 @@ impl<T: HasView<V, ViewType = Q> + AsMut<[u8]>, V, Q: AsMut<[u8]>> AsMut<[u8]>
     }
 }
 
-impl<D, T: HasView<V, ViewType = Q> + NextLayer<Denom = D>, V, Q> NextLayer
+impl<T: HasView<V, ViewType = Q> + NextLayer, V, Q> NextLayer
     for FieldMut<'_, T, V>
 where
-    D: Copy + Eq,
-    HeaderOf<T, V>: NextLayer<Denom = D>,
+    HeaderOf<T, V>: NextLayer<Denom = T::Denom>,
 {
-    type Denom = D;
+    type Denom = T::Denom;
 
     fn next_layer(&self) -> Option<Self::Denom> {
         match self {
@@ -154,13 +150,11 @@ where
     }
 }
 
-impl<D, D2, T: HasView<V, ViewType = Q> + NextLayerChoice<D2>, V, Q>
+impl<D2, T: HasView<V, ViewType = Q> + NextLayerChoice<D2>, V, Q>
     NextLayerChoice<D2> for FieldMut<'_, T, V>
 where
-    D: Copy + Eq,
     D2: Copy + Eq,
-    HeaderOf<T, V>: NextLayer<Denom = D> + NextLayerChoice<D2>,
-    T: NextLayer<Denom = D>,
+    HeaderOf<T, V>: NextLayer<Denom = T::Denom> + NextLayerChoice<D2>,
 {
     fn next_layer_choice(&self, hint: Option<D2>) -> Option<Self::Denom> {
         match self {

--- a/ingot-types/src/header.rs
+++ b/ingot-types/src/header.rs
@@ -117,9 +117,8 @@ impl<O, B> BoxedHeader<O, B> {
 
 #[cfg(feature = "alloc")]
 impl<
-        D: Copy + Eq,
-        O: NextLayer<Denom = D> + Clone,
-        B: NextLayer<Denom = D> + ToOwnedPacket<Target = O>,
+        O: NextLayer + Clone,
+        B: NextLayer<Denom = O::Denom> + ToOwnedPacket<Target = O>,
     > ToOwnedPacket for BoxedHeader<O, B>
 {
     type Target = O;
@@ -210,10 +209,10 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<D: Copy + Eq, D2, O: NextLayerChoice<D> + NextLayer<Denom = D2>, B>
-    NextLayerChoice<D> for BoxedHeader<O, B>
+impl<D: Copy + Eq, O: NextLayerChoice<D> + NextLayer, B> NextLayerChoice<D>
+    for BoxedHeader<O, B>
 where
-    B: NextLayerChoice<D> + NextLayer<Denom = D2>,
+    B: NextLayerChoice<D> + NextLayer<Denom = O::Denom>,
 {
     #[inline]
     fn next_layer_choice(&self, hint: Option<D>) -> Option<Self::Denom> {
@@ -291,9 +290,8 @@ impl<O, B> InlineHeader<O, B> {
 }
 
 impl<
-        D: Copy + Eq,
-        O: NextLayer<Denom = D> + Clone,
-        B: NextLayer<Denom = D> + ToOwnedPacket<Target = O>,
+        O: NextLayer + Clone,
+        B: NextLayer<Denom = O::Denom> + ToOwnedPacket<Target = O>,
     > ToOwnedPacket for InlineHeader<O, B>
 {
     type Target = O;

--- a/ingot-types/src/lib.rs
+++ b/ingot-types/src/lib.rs
@@ -217,7 +217,7 @@ pub type Success<T, B> = (T, Option<<T as NextLayer>::Denom>, B);
 /// next layer in a packet.
 pub trait NextLayer {
     /// The type of this header's next-layer hint.
-    type Denom: Copy;
+    type Denom: Copy + Eq;
 
     /// Retrieve this header's next-layer hint, if possible.
     #[inline]


### PR DESCRIPTION
(Staged on top of #24, but I could rebase it if you want)

In a bunch of blanket `impl`s, we manually provided a type `D` for `Denom`.  We can instead use `T::Denom` directly.  This makes some of the trait bounds simpler, but shouldn't change behavior.