### PR TITLE
Make Choice hint an associated type (3/)

### DIFF
--- a/ingot-macros/src/packet/mod.rs
+++ b/ingot-macros/src/packet/mod.rs
@@ -894,6 +894,16 @@ impl StructParseDeriveCtx {
                         #owned_body
                     }
                 }
+
+                impl<#g> ::ingot::types::NextLayerChoice for #ident<#g> {
+                    type Hint = ();
+
+                    #[inline]
+                    fn next_layer_choice(&self, _hint: ::core::option::Option<Self::Hint>) -> ::core::option::Option<Self::Denom> {
+                        use ::ingot::types::NextLayer;
+                        self.next_layer()
+                    }
+                }
             }
         } else {
             quote! {
@@ -903,6 +913,16 @@ impl StructParseDeriveCtx {
                     #[inline]
                     fn next_layer(&self) -> ::core::option::Option<Self::Denom> {
                         #owned_body
+                    }
+                }
+
+                impl ::ingot::types::NextLayerChoice for #ident {
+                    type Hint = ();
+
+                    #[inline]
+                    fn next_layer_choice(&self, _hint: ::core::option::Option<Self::Hint>) -> ::core::option::Option<Self::Denom> {
+                        use ::ingot::types::NextLayer;
+                        self.next_layer()
                     }
                 }
             }
@@ -915,6 +935,16 @@ impl StructParseDeriveCtx {
                 #[inline]
                 fn next_layer(&self) -> ::core::option::Option<Self::Denom> {
                     #ref_body
+                }
+            }
+
+            impl<V: ::zerocopy::ByteSlice> ::ingot::types::NextLayerChoice for #validated_ident<V> {
+                type Hint = ();
+
+                #[inline]
+                fn next_layer_choice(&self, _hint: ::core::option::Option<Self::Hint>) -> ::core::option::Option<Self::Denom> {
+                    use ::ingot::types::NextLayer;
+                    self.next_layer()
                 }
             }
 
@@ -1943,7 +1973,7 @@ impl StructParseDeriveCtx {
                     use ::ingot::types::ParseChoice;
                     use ::ingot::types::HeaderParse;
 
-                    let mut hint: Option<<Self as NextLayer>::Denom> = None;
+                    let mut hint: ::core::option::Option<<Self as NextLayer>::Denom> = None;
 
                     #( #segment_fragments )*
 
@@ -1960,11 +1990,10 @@ impl StructParseDeriveCtx {
             impl<
                 'a,
                 V: ::ingot::types::SplitByteSlice + ::ingot::types::IntoBufPointer<'a> + 'a,
-                AnyDenom: Copy + Eq
-            > ::ingot::types::ParseChoice<V, AnyDenom> for #validated_ident<V>
+            > ::ingot::types::ParseChoice<V> for #validated_ident<V>
             {
                 #[inline]
-                fn parse_choice(from: V, hint: Option<AnyDenom>) ->
+                fn parse_choice(from: V, hint: ::core::option::Option<Self::Hint>) ->
                     ::ingot::types::ParseResult<::ingot::types::Success<Self, V>>
                 {
                     use ::ingot::types::HeaderParse;
@@ -2024,7 +2053,7 @@ impl StructParseDeriveCtx {
                 type Target = #self_ty;
 
                 #[inline]
-                fn to_owned(&self, _hint: Option<Self::Denom>) -> ::ingot::types::ParseResult<Self::Target> {
+                fn to_owned(&self, _hint: ::core::option::Option<Self::Denom>) -> ::ingot::types::ParseResult<Self::Target> {
                     #self_ty::try_from(self).map_err(::ingot::types::ParseError::from)
                 }
             }

--- a/ingot-types/src/field.rs
+++ b/ingot-types/src/field.rs
@@ -70,13 +70,17 @@ where
     }
 }
 
-impl<D2, T: HasView<V, ViewType = Q> + NextLayerChoice<D2>, V, Q>
-    NextLayerChoice<D2> for FieldRef<'_, T, V>
+impl<T: HasView<V, ViewType = Q> + NextLayerChoice, V, Q> NextLayerChoice
+    for FieldRef<'_, T, V>
 where
-    D2: Copy + Eq,
-    HeaderOf<T, V>: NextLayer<Denom = T::Denom> + NextLayerChoice<D2>,
+    HeaderOf<T, V>:
+        NextLayer<Denom = T::Denom> + NextLayerChoice<Hint = T::Hint>,
 {
-    fn next_layer_choice(&self, hint: Option<D2>) -> Option<Self::Denom> {
+    type Hint = T::Hint;
+    fn next_layer_choice(
+        &self,
+        hint: Option<Self::Hint>,
+    ) -> Option<Self::Denom> {
         match self {
             FieldRef::Repr(r) => r.next_layer_choice(hint),
             FieldRef::Raw(r) => r.next_layer_choice(hint),
@@ -150,13 +154,17 @@ where
     }
 }
 
-impl<D2, T: HasView<V, ViewType = Q> + NextLayerChoice<D2>, V, Q>
-    NextLayerChoice<D2> for FieldMut<'_, T, V>
+impl<T: HasView<V, ViewType = Q> + NextLayerChoice, V, Q> NextLayerChoice
+    for FieldMut<'_, T, V>
 where
-    D2: Copy + Eq,
-    HeaderOf<T, V>: NextLayer<Denom = T::Denom> + NextLayerChoice<D2>,
+    HeaderOf<T, V>:
+        NextLayer<Denom = T::Denom> + NextLayerChoice<Hint = T::Hint>,
 {
-    fn next_layer_choice(&self, hint: Option<D2>) -> Option<Self::Denom> {
+    type Hint = T::Hint;
+    fn next_layer_choice(
+        &self,
+        hint: Option<Self::Hint>,
+    ) -> Option<Self::Denom> {
         match self {
             FieldMut::Repr(r) => r.next_layer_choice(hint),
             FieldMut::Raw(r) => r.next_layer_choice(hint),

--- a/ingot-types/src/header.rs
+++ b/ingot-types/src/header.rs
@@ -209,13 +209,17 @@ where
 }
 
 #[cfg(feature = "alloc")]
-impl<D: Copy + Eq, O: NextLayerChoice<D> + NextLayer, B> NextLayerChoice<D>
-    for BoxedHeader<O, B>
+impl<O: NextLayerChoice + NextLayer, B> NextLayerChoice for BoxedHeader<O, B>
 where
-    B: NextLayerChoice<D> + NextLayer<Denom = O::Denom>,
+    B: NextLayerChoice<Hint = O::Hint> + NextLayer<Denom = O::Denom>,
 {
+    type Hint = O::Hint;
+
     #[inline]
-    fn next_layer_choice(&self, hint: Option<D>) -> Option<Self::Denom> {
+    fn next_layer_choice(
+        &self,
+        hint: Option<Self::Hint>,
+    ) -> Option<Self::Denom> {
         match self {
             Self::Repr(v) => v.next_layer_choice(hint),
             Self::Raw(v) => v.next_layer_choice(hint),

--- a/ingot-types/src/lib.rs
+++ b/ingot-types/src/lib.rs
@@ -141,14 +141,12 @@ pub trait HeaderParse<B: SplitByteSlice>: NextLayer + Sized {
 
 /// A header/packet type which may require a hint to be parsed from
 /// any buffer `B`.
-pub trait ParseChoice<B: SplitByteSlice, Denom: Copy + Eq>:
-    Sized + NextLayer
-{
+pub trait ParseChoice<B: SplitByteSlice>: Sized + NextLayerChoice {
     /// Parse a view-type from a given buffer, using an optional
-    /// hint of type `Denom`.
+    /// hint of type.
     fn parse_choice(
         data: B,
-        hint: Option<Denom>,
+        hint: Option<Self::Hint>,
     ) -> ParseResult<Success<Self, B>>;
 }
 
@@ -228,12 +226,15 @@ pub trait NextLayer {
 
 /// Headers which can be queried for a hint, but require an input hint
 /// to parse this information.
-pub trait NextLayerChoice<Denom: Copy + Eq>: NextLayer {
+pub trait NextLayerChoice: NextLayer {
+    /// Associated type used for the input hint
+    type Hint: Copy + Eq;
+
     /// Retrieve this header's next-layer hint, if possible.
-    #[inline]
-    fn next_layer_choice(&self, _hint: Option<Denom>) -> Option<Self::Denom> {
-        self.next_layer()
-    }
+    fn next_layer_choice(
+        &self,
+        _hint: Option<Self::Hint>,
+    ) -> Option<Self::Denom>;
 }
 
 /// Action to be taken as part of an `#[ingot(control)]` block


### PR DESCRIPTION
(staged on top of #25)

This PR removes the generic argument from `NextLayerChoice` in favor of making it an associated type:

```rust
pub trait NextLayerChoice: NextLayer {
    /// Associated type used for the input hint
    type Hint: Copy + Eq;

    /// Retrieve this header's next-layer hint, if possible.
    fn next_layer_choice(
        &self,
        _hint: Option<Self::Hint>,
    ) -> Option<Self::Denom>;
}
```

This is a step towards parsing tagged values where the `Denom` of the inner type doesn't match the tag type (e.g. IGMP packets parsing into an `enum` based on `Hint = IgmpMessageType`, where each member of the `enum` has `Denom = ()`).