### PR TITLE
Combine `NextLayer` and `NextLayerChoice` (4/)

### DIFF
--- a/ingot-macros/src/choice.rs
+++ b/ingot-macros/src/choice.rs
@@ -49,8 +49,6 @@ pub fn attr_impl(attr: TokenStream, item: syn::ItemEnum) -> TokenStream {
     let mut next_layer_wheres_repr: Vec<TokenStream> = vec![];
     let mut next_layer_match_arms: Vec<TokenStream> = vec![];
 
-    let mut next_layer_choice_match_arms: Vec<TokenStream> = vec![];
-
     let mut from_ref_arms: Vec<TokenStream> = vec![];
 
     let mut unpacks: Vec<TokenStream> = vec![];
@@ -131,10 +129,6 @@ pub fn attr_impl(attr: TokenStream, item: syn::ItemEnum) -> TokenStream {
 
         next_layer_match_arms.push(quote! {
             Self::#id(v) => v.next_layer()
-        });
-
-        next_layer_choice_match_arms.push(quote! {
-            Self::#id(v) => v.next_layer_choice(None)
         });
 
         from_ref_arms.push(quote! {
@@ -273,9 +267,10 @@ pub fn attr_impl(attr: TokenStream, item: syn::ItemEnum) -> TokenStream {
         where #( #next_layer_wheres ),*
         {
             type Denom = T;
+            type Hint = #on;
 
             #[inline]
-            fn next_layer(&self) -> ::core::option::Option<Self::Denom> {
+            fn next_layer_choice(&self, hint: ::core::option::Option<Self::Hint>) -> ::core::option::Option<Self::Denom> {
                 match self {
                     #( #next_layer_match_arms ),*
                 }
@@ -286,35 +281,12 @@ pub fn attr_impl(attr: TokenStream, item: syn::ItemEnum) -> TokenStream {
         where #( #next_layer_wheres_repr ),*
         {
             type Denom = T;
+            type Hint = #on;
 
             #[inline]
-            fn next_layer(&self) -> ::core::option::Option<Self::Denom> {
+            fn next_layer_choice(&self, hint: ::core::option::Option<Self::Hint>) -> ::core::option::Option<Self::Denom> {
                 match self {
                     #( #next_layer_match_arms ),*
-                }
-            }
-        }
-
-        impl<V: ::ingot::types::ByteSlice> ::ingot::types::NextLayerChoice for #validated_ident<V>
-        {
-            type Hint = #on;
-
-            #[inline]
-            fn next_layer_choice(&self, _hint: ::core::option::Option<Self::Hint>) -> ::core::option::Option<Self::Denom> {
-                match self {
-                    #( #next_layer_choice_match_arms ),*
-                }
-            }
-        }
-
-        impl ::ingot::types::NextLayerChoice for #repr_head
-        {
-            type Hint = #on;
-
-            #[inline]
-            fn next_layer_choice(&self, _hint: ::core::option::Option<Self::Hint>) -> ::core::option::Option<Self::Denom> {
-                match self {
-                    #( #next_layer_choice_match_arms ),*
                 }
             }
         }

--- a/ingot-macros/src/packet/mod.rs
+++ b/ingot-macros/src/packet/mod.rs
@@ -854,7 +854,6 @@ impl StructParseDeriveCtx {
                 (
                     quote! {<#ref_ty as ::ingot::types::NextLayer>::Denom},
                     quote! {
-                        use ::ingot::types::NextLayerChoice;
                         use ::ingot::types::HeaderLen;
                         let h0 = ::core::option::Option::Some(self.#field_ident());
                         if self.#ref_ident().packet_length() == 0 {
@@ -888,20 +887,11 @@ impl StructParseDeriveCtx {
             quote! {
                 impl<#g> ::ingot::types::NextLayer for #ident<#g> {
                     type Denom = #denom;
-
-                    #[inline]
-                    fn next_layer(&self) -> ::core::option::Option<Self::Denom> {
-                        #owned_body
-                    }
-                }
-
-                impl<#g> ::ingot::types::NextLayerChoice for #ident<#g> {
                     type Hint = ();
 
                     #[inline]
                     fn next_layer_choice(&self, _hint: ::core::option::Option<Self::Hint>) -> ::core::option::Option<Self::Denom> {
-                        use ::ingot::types::NextLayer;
-                        self.next_layer()
+                        #owned_body
                     }
                 }
             }
@@ -909,20 +899,11 @@ impl StructParseDeriveCtx {
             quote! {
                 impl ::ingot::types::NextLayer for #ident {
                     type Denom = #denom;
-
-                    #[inline]
-                    fn next_layer(&self) -> ::core::option::Option<Self::Denom> {
-                        #owned_body
-                    }
-                }
-
-                impl ::ingot::types::NextLayerChoice for #ident {
                     type Hint = ();
 
                     #[inline]
                     fn next_layer_choice(&self, _hint: ::core::option::Option<Self::Hint>) -> ::core::option::Option<Self::Denom> {
-                        use ::ingot::types::NextLayer;
-                        self.next_layer()
+                        #owned_body
                     }
                 }
             }
@@ -931,20 +912,11 @@ impl StructParseDeriveCtx {
         quote! {
             impl<V: ::zerocopy::ByteSlice> ::ingot::types::NextLayer for #validated_ident<V> {
                 type Denom = #denom;
-
-                #[inline]
-                fn next_layer(&self) -> ::core::option::Option<Self::Denom> {
-                    #ref_body
-                }
-            }
-
-            impl<V: ::zerocopy::ByteSlice> ::ingot::types::NextLayerChoice for #validated_ident<V> {
                 type Hint = ();
 
                 #[inline]
                 fn next_layer_choice(&self, _hint: ::core::option::Option<Self::Hint>) -> ::core::option::Option<Self::Denom> {
-                    use ::ingot::types::NextLayer;
-                    self.next_layer()
+                    #ref_body
                 }
             }
 

--- a/ingot-macros/src/parse.rs
+++ b/ingot-macros/src/parse.rs
@@ -470,6 +470,7 @@ pub fn derive(input: DeriveInput, _args: ParserArgs) -> TokenStream {
 
         impl<V: ::ingot::types::ByteSlice> ::ingot::types::NextLayer for #ident<V> {
             type Denom = ();
+            type Hint = ();
         }
 
         impl<'a, V: ::ingot::types::SplitByteSlice + ::ingot::types::IntoBufPointer<'a> + 'a> ::ingot::types::HeaderParse<V> for #ident<V> {
@@ -482,6 +483,7 @@ pub fn derive(input: DeriveInput, _args: ParserArgs) -> TokenStream {
 
         impl<V: ::ingot::types::ByteSlice> ::ingot::types::NextLayer for #validated_ident<V> {
             type Denom = ();
+            type Hint = ();
         }
 
         impl<'a, V: ::ingot::types::SplitByteSlice + ::ingot::types::IntoBufPointer<'a> + 'a> ::ingot::types::HeaderParse<V> for #validated_ident<V> {

--- a/ingot-types/src/field.rs
+++ b/ingot-types/src/field.rs
@@ -58,25 +58,11 @@ impl<B: ByteSlice> FieldRef<'_, Vec<u8>, B> {
 impl<T: HasView<V, ViewType = Q> + NextLayer, V, Q> NextLayer
     for FieldRef<'_, T, V>
 where
-    HeaderOf<T, V>: NextLayer<Denom = T::Denom>,
+    HeaderOf<T, V>: NextLayer<Denom = T::Denom, Hint = T::Hint>,
 {
     type Denom = T::Denom;
-
-    fn next_layer(&self) -> Option<Self::Denom> {
-        match self {
-            FieldRef::Repr(r) => r.next_layer(),
-            FieldRef::Raw(r) => r.next_layer(),
-        }
-    }
-}
-
-impl<T: HasView<V, ViewType = Q> + NextLayerChoice, V, Q> NextLayerChoice
-    for FieldRef<'_, T, V>
-where
-    HeaderOf<T, V>:
-        NextLayer<Denom = T::Denom> + NextLayerChoice<Hint = T::Hint>,
-{
     type Hint = T::Hint;
+
     fn next_layer_choice(
         &self,
         hint: Option<Self::Hint>,
@@ -142,25 +128,11 @@ impl<T: HasView<V, ViewType = Q> + AsMut<[u8]>, V, Q: AsMut<[u8]>> AsMut<[u8]>
 impl<T: HasView<V, ViewType = Q> + NextLayer, V, Q> NextLayer
     for FieldMut<'_, T, V>
 where
-    HeaderOf<T, V>: NextLayer<Denom = T::Denom>,
+    HeaderOf<T, V>: NextLayer<Denom = T::Denom, Hint = T::Hint>,
 {
     type Denom = T::Denom;
-
-    fn next_layer(&self) -> Option<Self::Denom> {
-        match self {
-            FieldMut::Repr(r) => r.next_layer(),
-            FieldMut::Raw(r) => r.next_layer(),
-        }
-    }
-}
-
-impl<T: HasView<V, ViewType = Q> + NextLayerChoice, V, Q> NextLayerChoice
-    for FieldMut<'_, T, V>
-where
-    HeaderOf<T, V>:
-        NextLayer<Denom = T::Denom> + NextLayerChoice<Hint = T::Hint>,
-{
     type Hint = T::Hint;
+
     fn next_layer_choice(
         &self,
         hint: Option<Self::Hint>,

--- a/ingot-types/src/header.rs
+++ b/ingot-types/src/header.rs
@@ -118,7 +118,7 @@ impl<O, B> BoxedHeader<O, B> {
 #[cfg(feature = "alloc")]
 impl<
         O: NextLayer + Clone,
-        B: NextLayer<Denom = O::Denom> + ToOwnedPacket<Target = O>,
+        B: NextLayer<Denom = O::Denom, Hint = O::Hint> + ToOwnedPacket<Target = O>,
     > ToOwnedPacket for BoxedHeader<O, B>
 {
     type Target = O;
@@ -183,7 +183,7 @@ impl<
     > HeaderParse<V> for BoxedHeader<B::ReprType, B>
 where
     B: NextLayer,
-    B::ReprType: NextLayer<Denom = B::Denom>,
+    B::ReprType: NextLayer<Denom = B::Denom, Hint = B::Hint>,
 {
     #[inline]
     fn parse(from: V) -> ParseResult<Success<Self, V>> {
@@ -195,24 +195,9 @@ where
 #[cfg(feature = "alloc")]
 impl<O: NextLayer, B> NextLayer for BoxedHeader<O, B>
 where
-    B: NextLayer<Denom = O::Denom>,
+    B: NextLayer<Denom = O::Denom, Hint = O::Hint>,
 {
     type Denom = O::Denom;
-
-    #[inline]
-    fn next_layer(&self) -> Option<Self::Denom> {
-        match self {
-            Self::Repr(v) => v.next_layer(),
-            Self::Raw(v) => v.next_layer(),
-        }
-    }
-}
-
-#[cfg(feature = "alloc")]
-impl<O: NextLayerChoice + NextLayer, B> NextLayerChoice for BoxedHeader<O, B>
-where
-    B: NextLayerChoice<Hint = O::Hint> + NextLayer<Denom = O::Denom>,
-{
     type Hint = O::Hint;
 
     #[inline]
@@ -295,7 +280,7 @@ impl<O, B> InlineHeader<O, B> {
 
 impl<
         O: NextLayer + Clone,
-        B: NextLayer<Denom = O::Denom> + ToOwnedPacket<Target = O>,
+        B: NextLayer<Denom = O::Denom, Hint = O::Hint> + ToOwnedPacket<Target = O>,
     > ToOwnedPacket for InlineHeader<O, B>
 {
     type Target = O;
@@ -341,7 +326,7 @@ impl<
     > HeaderParse<V> for InlineHeader<B::ReprType, B>
 where
     B: NextLayer,
-    B::ReprType: NextLayer<Denom = B::Denom>,
+    B::ReprType: NextLayer<Denom = B::Denom, Hint = B::Hint>,
 {
     #[inline]
     fn parse(from: V) -> ParseResult<Success<Self, V>> {
@@ -352,15 +337,19 @@ where
 
 impl<O: NextLayer, B> NextLayer for InlineHeader<O, B>
 where
-    B: NextLayer<Denom = O::Denom>,
+    B: NextLayer<Denom = O::Denom, Hint = O::Hint>,
 {
     type Denom = O::Denom;
+    type Hint = O::Hint;
 
     #[inline]
-    fn next_layer(&self) -> Option<Self::Denom> {
+    fn next_layer_choice(
+        &self,
+        hint: Option<Self::Hint>,
+    ) -> Option<Self::Denom> {
         match self {
-            Self::Repr(v) => v.next_layer(),
-            Self::Raw(v) => v.next_layer(),
+            Self::Repr(v) => v.next_layer_choice(hint),
+            Self::Raw(v) => v.next_layer_choice(hint),
         }
     }
 }

--- a/ingot-types/src/lib.rs
+++ b/ingot-types/src/lib.rs
@@ -141,7 +141,7 @@ pub trait HeaderParse<B: SplitByteSlice>: NextLayer + Sized {
 
 /// A header/packet type which may require a hint to be parsed from
 /// any buffer `B`.
-pub trait ParseChoice<B: SplitByteSlice>: Sized + NextLayerChoice {
+pub trait ParseChoice<B: SplitByteSlice>: Sized + NextLayer {
     /// Parse a view-type from a given buffer, using an optional
     /// hint of type.
     fn parse_choice(
@@ -217,24 +217,23 @@ pub trait NextLayer {
     /// The type of this header's next-layer hint.
     type Denom: Copy + Eq;
 
-    /// Retrieve this header's next-layer hint, if possible.
-    #[inline]
-    fn next_layer(&self) -> Option<Self::Denom> {
-        None
-    }
-}
-
-/// Headers which can be queried for a hint, but require an input hint
-/// to parse this information.
-pub trait NextLayerChoice: NextLayer {
-    /// Associated type used for the input hint
+    /// A type used to help parse the header
     type Hint: Copy + Eq;
 
     /// Retrieve this header's next-layer hint, if possible.
+    #[inline]
+    fn next_layer(&self) -> Option<Self::Denom> {
+        self.next_layer_choice(None)
+    }
+
+    /// Try to retrieve this header's next-layer hint, using a provided hint
+    #[inline]
     fn next_layer_choice(
         &self,
         _hint: Option<Self::Hint>,
-    ) -> Option<Self::Denom>;
+    ) -> Option<Self::Denom> {
+        None
+    }
 }
 
 /// Action to be taken as part of an `#[ingot(control)]` block

--- a/ingot/src/tests.rs
+++ b/ingot/src/tests.rs
@@ -14,8 +14,8 @@ use crate::{
     },
     types::{
         primitives::*, util::RepeatedView, Accessor, Emit, HeaderLen,
-        HeaderParse, Ipv6Addr, NextLayer, NextLayerChoice, ParseChoice,
-        ParseError, ToOwnedPacket,
+        HeaderParse, Ipv6Addr, NextLayer, ParseChoice, ParseError,
+        ToOwnedPacket,
     },
     udp::{Udp, UdpRef, ValidUdp, _Udp_ingot_impl::UdpPart0},
     Ingot,


### PR DESCRIPTION
Staged on top of #26

We always implement both traits together, so combining them lets us consolidate a bunch of trait bounds.