### PR TITLE
Add `ToOwnedPacket` to choice types

### DIFF
--- a/ingot-macros/src/choice.rs
+++ b/ingot-macros/src/choice.rs
@@ -291,6 +291,14 @@ pub fn attr_impl(attr: TokenStream, item: syn::ItemEnum) -> TokenStream {
             }
         }
 
+        impl<V: ::ingot::types::SplitByteSlice> ::ingot::types::ToOwnedPacket for #validated_ident<V> {
+            type Target = #repr_head;
+            #[inline]
+            fn to_owned(&self, _hint: ::core::option::Option<Self::Hint>) -> ::ingot::types::ParseResult<Self::Target> {
+                self.try_into()
+            }
+        }
+
         impl<V: ::ingot::types::ByteSlice> ::ingot::types::HeaderLen for #ident<V> {
             const MINIMUM_LENGTH: usize = #minimum_len;
 

--- a/ingot-macros/src/packet/mod.rs
+++ b/ingot-macros/src/packet/mod.rs
@@ -2025,7 +2025,7 @@ impl StructParseDeriveCtx {
                 type Target = #self_ty;
 
                 #[inline]
-                fn to_owned(&self, _hint: ::core::option::Option<Self::Denom>) -> ::ingot::types::ParseResult<Self::Target> {
+                fn to_owned(&self, _hint: ::core::option::Option<Self::Hint>) -> ::ingot::types::ParseResult<Self::Target> {
                     #self_ty::try_from(self).map_err(::ingot::types::ParseError::from)
                 }
             }

--- a/ingot-types/src/header.rs
+++ b/ingot-types/src/header.rs
@@ -123,7 +123,7 @@ impl<
 {
     type Target = O;
 
-    fn to_owned(&self, hint: Option<Self::Denom>) -> ParseResult<Self::Target> {
+    fn to_owned(&self, hint: Option<Self::Hint>) -> ParseResult<Self::Target> {
         match self {
             Header::Repr(o) => Ok(*o.clone()),
             Header::Raw(v) => v.to_owned(hint),
@@ -285,7 +285,7 @@ impl<
 {
     type Target = O;
 
-    fn to_owned(&self, hint: Option<Self::Denom>) -> ParseResult<Self::Target> {
+    fn to_owned(&self, hint: Option<Self::Hint>) -> ParseResult<Self::Target> {
         match self {
             Self::Repr(o) => Ok(o.clone()),
             Self::Raw(v) => v.to_owned(hint),

--- a/ingot-types/src/lib.rs
+++ b/ingot-types/src/lib.rs
@@ -59,7 +59,7 @@ pub trait ToOwnedPacket: NextLayer {
 
     /// Converts a borrowed view of a header into an owned version, possibly
     /// reparsing to do so with the aid of `hint`.
-    fn to_owned(&self, hint: Option<Self::Denom>) -> ParseResult<Self::Target>;
+    fn to_owned(&self, hint: Option<Self::Hint>) -> ParseResult<Self::Target>;
 }
 
 /// Base trait for header/packet types.


### PR DESCRIPTION
Previously, we couldn't store a single `subparse(on_next_layer)` field, because `ToOwnedPacket` was not implemented by `ingot::macros::choice` (it did have a blanket `impl` for `RepeatedView`, so it worked for all of our current packets).

As another step towards `enum`-flavored parsing, this PR adds the relevant implementation.  Note that it only works for homogeneous layers, i.e. they must share the same `Hint` / `Denom`.

I also changed the hint type in `to_owned_packet` from `Self::Denom` to `Self::Hint`, which I _think_ is correct.