### PR TITLE
Combine `HeaderParse` and `ParseChoice`

### DIFF
--- a/ingot-examples/benches/choice.rs
+++ b/ingot-examples/benches/choice.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use ingot::{ethernet::Ethertype, types::ParseChoice};
+use ingot::{ethernet::Ethertype, types::HeaderParse};
 use ingot_examples::choices::ValidL3;
 use std::hint::black_box;
 

--- a/ingot-macros/src/choice.rs
+++ b/ingot-macros/src/choice.rs
@@ -291,6 +291,14 @@ pub fn attr_impl(attr: TokenStream, item: syn::ItemEnum) -> TokenStream {
             }
         }
 
+        impl<V: ::ingot::types::SplitByteSlice> ::ingot::types::ToOwnedPacket for #validated_ident<V> {
+            type Target = #repr_head;
+            #[inline]
+            fn to_owned(&self, _hint: ::core::option::Option<Self::Hint>) -> ::ingot::types::ParseResult<Self::Target> {
+                self.try_into()
+            }
+        }
+
         impl<V: ::ingot::types::ByteSlice> ::ingot::types::HeaderLen for #ident<V> {
             const MINIMUM_LENGTH: usize = #minimum_len;
 

--- a/ingot-macros/src/choice.rs
+++ b/ingot-macros/src/choice.rs
@@ -228,7 +228,7 @@ pub fn attr_impl(attr: TokenStream, item: syn::ItemEnum) -> TokenStream {
             #( #repr_vars ),*
         }
 
-        impl<'a, V: ::ingot::types::SplitByteSlice + ::ingot::types::IntoBufPointer<'a> + 'a> ::ingot::types::ParseChoice<V> for #validated_ident<V> {
+        impl<'a, V: ::ingot::types::SplitByteSlice + ::ingot::types::IntoBufPointer<'a> + 'a> ::ingot::types::HeaderParse<V> for #validated_ident<V> {
             #[inline]
             fn parse_choice(data: V, hint: ::core::option::Option<Self::Hint>) -> ::ingot::types::ParseResult<::ingot::types::Success<Self, V>> {
                 use ::ingot::types::HeaderParse;

--- a/ingot-macros/src/lib.rs
+++ b/ingot-macros/src/lib.rs
@@ -162,7 +162,7 @@ pub fn derive_ingot(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///
 /// Ingot will define three `enum`s from this definition: `L4` (owned/borrowed),
 /// `ValidL4` (borrowed), and `L4Repr` (owned).
-/// All implement `Emit`, while `ValidL4`will implement `ParseChoice`.
+/// All implement `Emit`, while `ValidL4`will implement `HeaderParse`.
 ///
 /// ## Top-level attributes
 /// * `#[choice(on = <type>)]` – The input type of hint used for selection

--- a/ingot-macros/src/packet/mod.rs
+++ b/ingot-macros/src/packet/mod.rs
@@ -2025,7 +2025,7 @@ impl StructParseDeriveCtx {
                 type Target = #self_ty;
 
                 #[inline]
-                fn to_owned(&self, _hint: ::core::option::Option<Self::Denom>) -> ::ingot::types::ParseResult<Self::Target> {
+                fn to_owned(&self, _hint: ::core::option::Option<Self::Hint>) -> ::ingot::types::ParseResult<Self::Target> {
                     #self_ty::try_from(self).map_err(::ingot::types::ParseError::from)
                 }
             }

--- a/ingot-macros/src/packet/mod.rs
+++ b/ingot-macros/src/packet/mod.rs
@@ -1938,11 +1938,10 @@ impl StructParseDeriveCtx {
                 V: ::ingot::types::SplitByteSlice + ::ingot::types::IntoBufPointer<'a> + 'a
             > ::ingot::types::HeaderParse<V> for #validated_ident<V> {
                 #[inline]
-                fn parse(from: V) -> ::ingot::types::ParseResult<::ingot::types::Success<Self, V>> {
+                fn parse_choice(from: V, _hint: ::core::option::Option<Self::Hint>) -> ::ingot::types::ParseResult<::ingot::types::Success<Self, V>> {
                     use ::ingot::types::HeaderLen;
                     use ::ingot::types::HasView;
                     use ::ingot::types::NextLayer;
-                    use ::ingot::types::ParseChoice;
                     use ::ingot::types::HeaderParse;
 
                     let mut hint: ::core::option::Option<<Self as NextLayer>::Denom> = None;
@@ -1956,20 +1955,6 @@ impl StructParseDeriveCtx {
                     ::core::result::Result::Ok(
                         (val, hint, from)
                     )
-                }
-            }
-
-            impl<
-                'a,
-                V: ::ingot::types::SplitByteSlice + ::ingot::types::IntoBufPointer<'a> + 'a,
-            > ::ingot::types::ParseChoice<V> for #validated_ident<V>
-            {
-                #[inline]
-                fn parse_choice(from: V, hint: ::core::option::Option<Self::Hint>) ->
-                    ::ingot::types::ParseResult<::ingot::types::Success<Self, V>>
-                {
-                    use ::ingot::types::HeaderParse;
-                    Self::parse(from)
                 }
             }
         }

--- a/ingot-macros/src/parse.rs
+++ b/ingot-macros/src/parse.rs
@@ -450,7 +450,6 @@ pub fn derive(input: DeriveInput, _args: ParserArgs) -> TokenStream {
     let imports = quote! {
         use ::ingot::types::HasView;
         use ::ingot::types::NextLayer;
-        use ::ingot::types::ParseChoice;
         use ::ingot::types::HeaderParse;
     };
 
@@ -475,7 +474,7 @@ pub fn derive(input: DeriveInput, _args: ParserArgs) -> TokenStream {
 
         impl<'a, V: ::ingot::types::SplitByteSlice + ::ingot::types::IntoBufPointer<'a> + 'a> ::ingot::types::HeaderParse<V> for #ident<V> {
             #[inline]
-            fn parse(from: V) -> ::ingot::types::ParseResult<::ingot::types::Success<Self, V>> {
+            fn parse_choice(from: V, _hint: ::core::option::Option<Self::Hint>) -> ::ingot::types::ParseResult<::ingot::types::Success<Self, V>> {
                 Self::parse_slice(from)
                     .map_err(|e| e.into())
             }
@@ -488,7 +487,7 @@ pub fn derive(input: DeriveInput, _args: ParserArgs) -> TokenStream {
 
         impl<'a, V: ::ingot::types::SplitByteSlice + ::ingot::types::IntoBufPointer<'a> + 'a> ::ingot::types::HeaderParse<V> for #validated_ident<V> {
             #[inline]
-            fn parse(from: V) -> ::ingot::types::ParseResult<::ingot::types::Success<Self, V>> {
+            fn parse_choice(from: V, _hint: ::core::option::Option<Self::Hint>) -> ::ingot::types::ParseResult<::ingot::types::Success<Self, V>> {
                 Self::parse_slice(from)
                     .map_err(|e| e.into())
             }

--- a/ingot-types/src/header.rs
+++ b/ingot-types/src/header.rs
@@ -186,8 +186,11 @@ where
     B::ReprType: NextLayer<Denom = B::Denom, Hint = B::Hint>,
 {
     #[inline]
-    fn parse(from: V) -> ParseResult<Success<Self, V>> {
-        <B as HeaderParse<V>>::parse(from)
+    fn parse_choice(
+        from: V,
+        hint: Option<Self::Hint>,
+    ) -> ParseResult<Success<Self, V>> {
+        <B as HeaderParse<V>>::parse_choice(from, hint)
             .map(|(val, hint, remainder)| (val.into(), hint, remainder))
     }
 }
@@ -329,8 +332,11 @@ where
     B::ReprType: NextLayer<Denom = B::Denom, Hint = B::Hint>,
 {
     #[inline]
-    fn parse(from: V) -> ParseResult<Success<Self, V>> {
-        <B as HeaderParse<V>>::parse(from)
+    fn parse_choice(
+        from: V,
+        hint: Option<Self::Hint>,
+    ) -> ParseResult<Success<Self, V>> {
+        <B as HeaderParse<V>>::parse_choice(from, hint)
             .map(|(val, hint, remainder)| (val.into(), hint, remainder))
     }
 }

--- a/ingot-types/src/header.rs
+++ b/ingot-types/src/header.rs
@@ -123,7 +123,7 @@ impl<
 {
     type Target = O;
 
-    fn to_owned(&self, hint: Option<Self::Denom>) -> ParseResult<Self::Target> {
+    fn to_owned(&self, hint: Option<Self::Hint>) -> ParseResult<Self::Target> {
         match self {
             Header::Repr(o) => Ok(*o.clone()),
             Header::Raw(v) => v.to_owned(hint),
@@ -285,7 +285,7 @@ impl<
 {
     type Target = O;
 
-    fn to_owned(&self, hint: Option<Self::Denom>) -> ParseResult<Self::Target> {
+    fn to_owned(&self, hint: Option<Self::Hint>) -> ParseResult<Self::Target> {
         match self {
             Self::Repr(o) => Ok(o.clone()),
             Self::Raw(v) => v.to_owned(hint),

--- a/ingot-types/src/lib.rs
+++ b/ingot-types/src/lib.rs
@@ -136,14 +136,10 @@ impl<T: HasRepr> HasRepr for Option<T> {
 /// buffer `B`.
 pub trait HeaderParse<B: SplitByteSlice>: NextLayer + Sized {
     /// Parse a view-type from a given buffer.
-    fn parse(from: B) -> ParseResult<Success<Self, B>>;
-}
-
-/// A header/packet type which may require a hint to be parsed from
-/// any buffer `B`.
-pub trait ParseChoice<B: SplitByteSlice>: Sized + NextLayer {
-    /// Parse a view-type from a given buffer, using an optional
-    /// hint of type.
+    fn parse(from: B) -> ParseResult<Success<Self, B>> {
+        Self::parse_choice(from, None)
+    }
+    /// Parse a view-type from a given buffer, using a hint
     fn parse_choice(
         data: B,
         hint: Option<Self::Hint>,

--- a/ingot-types/src/lib.rs
+++ b/ingot-types/src/lib.rs
@@ -59,7 +59,7 @@ pub trait ToOwnedPacket: NextLayer {
 
     /// Converts a borrowed view of a header into an owned version, possibly
     /// reparsing to do so with the aid of `hint`.
-    fn to_owned(&self, hint: Option<Self::Denom>) -> ParseResult<Self::Target>;
+    fn to_owned(&self, hint: Option<Self::Hint>) -> ParseResult<Self::Target>;
 }
 
 /// Base trait for header/packet types.

--- a/ingot-types/src/util.rs
+++ b/ingot-types/src/util.rs
@@ -184,13 +184,11 @@ where
 impl<
         B: SplitByteSlice,
         T: HasView<B> + NextLayer<Hint = <T as NextLayer>::Denom>,
-    > ParseChoice<B> for RepeatedView<B, T>
+    > HeaderParse<B> for RepeatedView<B, T>
 where
     T: for<'a> HasView<&'a [u8]>,
-    <T as HasView<B>>::ViewType:
-        ParseChoice<B, Hint = T::Hint> + NextLayer<Denom = T::Denom>,
     for<'a> <T as HasView<&'a [u8]>>::ViewType:
-        ParseChoice<&'a [u8], Hint = T::Hint> + NextLayer<Denom = T::Denom>,
+        HeaderParse<&'a [u8]> + NextLayer<Denom = T::Denom, Hint = T::Hint>,
 {
     #[inline]
     fn parse_choice(
@@ -236,7 +234,7 @@ impl<
 where
     T: for<'a> HasView<&'a [u8]>,
     for<'a> <T as HasView<&'a [u8]>>::ViewType:
-        ParseChoice<&'a [u8]> + NextLayer<Denom = T::Denom, Hint = T::Hint>,
+        HeaderParse<&'a [u8]> + NextLayer<Denom = T::Denom, Hint = T::Hint>,
     for<'a, 'b> &'b <T as HasView<&'a [u8]>>::ViewType: TryInto<T, Error = E>,
     // Bound needed to account for `Infallible` errors via pure `From`/`Into`.
     ParseError: From<E>,
@@ -283,7 +281,7 @@ impl<'a, T: HasView<&'a [u8]> + NextLayer<Hint = <T as NextLayer>::Denom>>
     Iterator for RepeatedViewIter<'a, T>
 where
     <T as HasView<&'a [u8]>>::ViewType:
-        ParseChoice<&'a [u8]> + NextLayer<Denom = T::Denom, Hint = T::Hint>,
+        HeaderParse<&'a [u8]> + NextLayer<Denom = T::Denom, Hint = T::Hint>,
 {
     type Item = ParseResult<<T as HasView<&'a [u8]>>::ViewType>;
 
@@ -315,7 +313,7 @@ impl<
     > NextLayer for RepeatedView<B, T>
 where
     for<'a> <T as HasView<&'a [u8]>>::ViewType:
-        ParseChoice<&'a [u8]> + NextLayer<Denom = T::Denom, Hint = T::Hint>,
+        HeaderParse<&'a [u8]> + NextLayer<Denom = T::Denom, Hint = T::Hint>,
 {
     type Denom = T::Denom;
     type Hint = T::Hint;

--- a/ingot/src/tests.rs
+++ b/ingot/src/tests.rs
@@ -15,8 +15,7 @@ use crate::{
     },
     types::{
         primitives::*, util::RepeatedView, Accessor, Emit, HeaderLen,
-        HeaderParse, Ipv6Addr, NextLayer, ParseChoice, ParseError,
-        ToOwnedPacket,
+        HeaderParse, Ipv6Addr, NextLayer, ParseError, ToOwnedPacket,
     },
     udp::{Udp, UdpRef, ValidUdp, _Udp_ingot_impl::UdpPart0},
     Ingot,


### PR DESCRIPTION
(staged on top of #28)

This is analogous to #27: we can simplify the combination of `HeaderParse` and `ParseChoice` by moving everything into `HeaderParse`, with a default implementation for `parse()`.