### PR TITLE
Move hint fallback into `Repeated` / `RepeatedView`

### DIFF
--- a/ingot-macros/src/packet/mod.rs
+++ b/ingot-macros/src/packet/mod.rs
@@ -856,19 +856,12 @@ impl StructParseDeriveCtx {
                     quote! {
                         use ::ingot::types::HeaderLen;
                         let h0 = ::core::option::Option::Some(self.#field_ident());
-                        if self.#ref_ident().packet_length() == 0 {
-                            h0
-                        } else {
-                            self.#ref_ident().next_layer_choice(h0)
-                        }
+                        self.#ref_ident().next_layer_choice(h0)
                     },
                     quote! {
                         use ::ingot::types::HeaderLen;
-                        if self.#subparse_ident.packet_length() == 0 {
-                            Some(self.#field_ident)
-                        } else {
-                            self.#subparse_ident.next_layer()
-                        }
+                        let h0 = ::core::option::Option::Some(self.#field_ident);
+                        self.#subparse_ident.next_layer_choice(h0)
                     },
                 )
             } else {

--- a/ingot-types/src/util.rs
+++ b/ingot-types/src/util.rs
@@ -98,16 +98,21 @@ impl<T: Emit> Emit for Repeated<T> {
     }
 }
 
-impl<T: NextLayer> NextLayer for Repeated<T> {
+impl<T> NextLayer for Repeated<T>
+where
+    T: NextLayer<Hint = <T as NextLayer>::Denom>,
+{
     type Denom = T::Denom;
     type Hint = T::Hint;
 
     fn next_layer_choice(
         &self,
-        _hint: Option<Self::Hint>,
+        hint: Option<Self::Hint>,
     ) -> Option<Self::Denom> {
         // Choose the hint attached to the last item contained herein.
-        self.inner.last().and_then(|v| v.next_layer())
+        //
+        // If the inner Vec is empty, then return the outer hint
+        self.inner.last().and_then(|v| v.next_layer()).or(hint)
     }
 }
 
@@ -322,7 +327,11 @@ where
         &self,
         hint: Option<Self::Hint>,
     ) -> Option<Self::Denom> {
-        self.iter(hint).last().and_then(|v| v.ok()).and_then(|v| v.next_layer())
+        self.iter(hint)
+            .last()
+            .and_then(|v| v.ok())
+            .and_then(|v| v.next_layer())
+            .or(hint)
     }
 }
 


### PR DESCRIPTION
(staged on top of #30)

The existing `NextLayer` implementation requires the `Hint` and `Denom` to be the same, which prevents heterogeneous `next_layer` parsing.  This is for the sake of the `Repeated` and `RepeatedView` types, where the next layer may be empty.

This PR moves fallback handling of an empty repeated layer into `Repeated` and `RepeatedView`, allowing for heterogeneous subparsing using existing traits.