### PR TITLE
ICMP support work for opte#369

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "autocfg"
@@ -31,15 +31,15 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "cast"
@@ -82,18 +82,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "criterion"
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -162,21 +162,21 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "fnv"
@@ -221,9 +221,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "ident_case"
@@ -286,13 +286,13 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -315,30 +315,31 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "macaddr"
@@ -363,15 +364,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "plotters"
@@ -403,18 +404,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -453,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -469,10 +470,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
+name = "rustversion"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -485,18 +492,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -505,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -523,9 +530,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -544,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "walkdir"
@@ -560,24 +567,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -586,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -596,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -609,15 +616,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -629,16 +639,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
+ "windows-sys",
 ]
 
 [[package]]
@@ -716,18 +717,18 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.7"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb3da5f7220f919a6c7af7c856435a68ee1582fd7a77aa72936257d8335bd6f6"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.7"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5f54f3cc93cd80745404626681b4b9fca9a867bad5a8424b618eb0db1ae6ea"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ingot-macros/src/lib.rs
+++ b/ingot-macros/src/lib.rs
@@ -123,6 +123,7 @@ pub fn derive_parse(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///   with the `is` attribute.
 ///   - `#[ingot(subparse(on_next_layer))]` – parses this field using the `next_layer`
 ///     field to make a choice. This field will be used as the source of the next header.
+/// * `#[ingot(var_len)]` – Consumes the remainder of the provided slice as a `Vec<u8>`.
 /// * `#[ingot(var_len = "<expr>")]` – Determines the length of a `Vec<u8>` field,
 ///   or provides an exact length for a variable-length subparse. This expression
 ///   can access any prior fixed-width field.

--- a/ingot-macros/src/packet/mod.rs
+++ b/ingot-macros/src/packet/mod.rs
@@ -546,9 +546,19 @@ impl StructParseDeriveCtx {
 
         // first pass: split struct into discrete chunks, ensure byte
         // alignment in the right spots.
+        let n_fields = field_data.fields.len();
         for (idx, field) in field_data.fields.iter().enumerate() {
             let field_ident = field.ident.as_ref().unwrap().clone();
             let user_ty = field.ty.clone();
+            let is_last = idx == n_fields - 1;
+
+            if !is_last && matches!(field.var_len, VarlenType::Remainder) {
+                return Err(Error::new(
+                    field_ident.span(),
+                    "only the last field in a header may be `var_len` without a \
+                    limit expression",
+                ));
+            }
 
             let state = match (
                 &field.zerocopy,

--- a/ingot/src/geneve.rs
+++ b/ingot/src/geneve.rs
@@ -185,7 +185,7 @@ impl core::fmt::Display for Vni {
 // it in a human-friendly manner.
 impl core::fmt::Debug for Vni {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        write!(f, "Vni {{ inner: {} }}", self)
+        write!(f, "Vni {{ inner: {self} }}")
     }
 }
 

--- a/ingot/src/icmp.rs
+++ b/ingot/src/icmp.rs
@@ -15,7 +15,7 @@ impl IcmpV4Type {
     pub const DESTINATION_UNREACHABLE: Self = Self(3);
     pub const SOURCE_QUENCH: Self = Self(4);
     pub const REDIRECT: Self = Self(5);
-    pub const ECHO: Self = Self(8);
+    pub const ECHO_REQUEST: Self = Self(8);
     pub const ROUTER_ADVERTISEMENT: Self = Self(9);
     pub const ROUTER_SOLICITATION: Self = Self(10);
     pub const TIME_EXCEEDED: Self = Self(11);
@@ -23,7 +23,10 @@ impl IcmpV4Type {
     pub const TIMESTAMP: Self = Self(13);
     pub const TIMESTAMP_REPLY: Self = Self(14);
 
-    /// This packet's payload
+    /// This ICMP packet's payload contains a portion of the packet it was
+    /// generated in response to.
+    ///
+    /// This consists of the IPv4 header and 8 bytes of the upper protocol.
     pub const fn payload_is_packet(self) -> bool {
         matches!(
             self,
@@ -72,7 +75,11 @@ impl IcmpV6Type {
     pub const ROUTER_RENUMBER: Self = Self(138);
     pub const RESERVED_INFO: Self = Self(255);
 
-    /// This packet's payload
+    /// This ICMPv6 packet's payload contains a portion of the packet it was
+    /// generated in response to.
+    ///
+    /// This consists of at least the IPv6 header, and as many bytes as can
+    /// be fit using the currently known MTU.
     pub const fn payload_is_packet(self) -> bool {
         matches!(
             self,
@@ -83,14 +90,22 @@ impl IcmpV6Type {
         )
     }
 
+    /// This ICMPv6 message is sent in response to a problematic packet.
     pub const fn is_error(self) -> bool {
         self.0 < 128
     }
 
+    /// This ICMPv6 message is informational, used in active/passive network
+    /// monitoring/diagnostics.
     pub const fn is_informational(self) -> bool {
         self.0 >= 128
     }
 
+    /// This ICMPv6 message is part of the Neighbor Discovery Protocol ([rfc4861]).
+    /// Its payload consists of a set of [`Option`] TLV messages.
+    ///
+    /// [rfc4861]: https://datatracker.ietf.org/doc/html/rfc4861
+    /// [`Option`]: ndisc::Option
     pub const fn is_neighbor_discovery(self) -> bool {
         self.0 >= Self::ROUTER_SOLICITATION.0 && self.0 <= Self::REDIRECT.0
     }

--- a/ingot/src/icmp.rs
+++ b/ingot/src/icmp.rs
@@ -185,7 +185,7 @@ pub mod ndisc {
     pub struct OptionRedirect {
         rsvd: [u8; 6],
         #[ingot(var_len)]
-        pub data: Vec<u8>,
+        pub original_packet: Vec<u8>,
     }
 
     #[derive(Clone, Debug, Eq, PartialEq, Ingot)]

--- a/ingot/src/icmp.rs
+++ b/ingot/src/icmp.rs
@@ -3,22 +3,180 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use ingot_macros::Ingot;
-use ingot_types::primitives::u16be;
+use ingot_types::{primitives::*, Vec};
+
+ingot_types::zerocopy_type!(
+    #[derive(Default)]
+    pub struct IcmpV4Type(pub u8)
+);
+
+impl IcmpV4Type {
+    pub const ECHO_REPLY: Self = Self(0);
+    pub const DESTINATION_UNREACHABLE: Self = Self(3);
+    pub const SOURCE_QUENCH: Self = Self(4);
+    pub const REDIRECT: Self = Self(5);
+    pub const ECHO: Self = Self(8);
+    pub const ROUTER_ADVERTISEMENT: Self = Self(9);
+    pub const ROUTER_SOLICITATION: Self = Self(10);
+    pub const TIME_EXCEEDED: Self = Self(11);
+    pub const PARAMETER_PROBLEM: Self = Self(12);
+    pub const TIMESTAMP: Self = Self(13);
+    pub const TIMESTAMP_REPLY: Self = Self(14);
+
+    /// This packet's payload
+    pub const fn payload_is_packet(self) -> bool {
+        matches!(
+            self,
+            Self::DESTINATION_UNREACHABLE
+                | Self::SOURCE_QUENCH
+                | Self::REDIRECT
+                | Self::TIME_EXCEEDED
+                | Self::PARAMETER_PROBLEM
+        )
+    }
+}
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Ingot)]
 #[ingot(impl_default)]
 pub struct IcmpV4 {
-    pub ty: u8,
+    #[ingot(zerocopy)]
+    pub ty: IcmpV4Type,
     pub code: u8,
     pub checksum: u16be,
     pub rest_of_hdr: [u8; 4],
 }
 
+ingot_types::zerocopy_type!(
+    #[derive(Default)]
+    pub struct IcmpV6Type(pub u8)
+);
+
+impl IcmpV6Type {
+    pub const RESERVED: Self = Self(0);
+    pub const DESTINATION_UNREACHABLE: Self = Self(1);
+    pub const PACKET_TOO_BIG: Self = Self(2);
+    pub const TIME_EXCEEDED: Self = Self(3);
+    pub const PARAMETER_PROBLEM: Self = Self(4);
+    pub const RESERVED_ERR: Self = Self(127);
+
+    pub const ECHO_REQUEST: Self = Self(128);
+    pub const ECHO_REPLY: Self = Self(129);
+    pub const MULTICAST_LISTENER_QUERY: Self = Self(130);
+    pub const MULTICAST_LISTENER_REPORT: Self = Self(131);
+    pub const MULTICAST_LISTENER_DONE: Self = Self(132);
+    pub const ROUTER_SOLICITATION: Self = Self(133);
+    pub const ROUTER_ADVERTISEMENT: Self = Self(134);
+    pub const NEIGHBOR_SOLICITATION: Self = Self(135);
+    pub const NEIGHBOR_ADVERTISEMENT: Self = Self(136);
+    pub const REDIRECT: Self = Self(137);
+    pub const ROUTER_RENUMBER: Self = Self(138);
+    pub const RESERVED_INFO: Self = Self(255);
+
+    /// This packet's payload
+    pub const fn payload_is_packet(self) -> bool {
+        matches!(
+            self,
+            Self::DESTINATION_UNREACHABLE
+                | Self::TIME_EXCEEDED
+                | Self::PARAMETER_PROBLEM
+                | Self::PACKET_TOO_BIG
+        )
+    }
+
+    pub const fn is_error(self) -> bool {
+        self.0 < 128
+    }
+
+    pub const fn is_informational(self) -> bool {
+        self.0 >= 128
+    }
+
+    pub const fn is_neighbor_discovery(self) -> bool {
+        self.0 >= Self::ROUTER_SOLICITATION.0 && self.0 <= Self::REDIRECT.0
+    }
+}
+
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, Ingot)]
 #[ingot(impl_default)]
 pub struct IcmpV6 {
-    pub ty: u8,
+    #[ingot(zerocopy)]
+    pub ty: IcmpV6Type,
     pub code: u8,
     pub checksum: u16be,
     pub rest_of_hdr: [u8; 4],
+}
+
+pub mod ndisc {
+    //! Header types related to the Neighbor Discovery Protocol within ICMPv6.
+    use bitflags::bitflags;
+    use ingot_types::{Ipv6Addr, NetworkRepr};
+
+    use super::*;
+
+    ingot_types::zerocopy_type!(
+        #[derive(Default)]
+        pub struct OptionType(pub u8)
+    );
+
+    impl OptionType {
+        pub const SOURCE_LL_ADDRESS: Self = Self(1);
+        pub const TARGET_LL_ADDRESS: Self = Self(2);
+        pub const PREFIX_INFO: Self = Self(3);
+        pub const REDIRECTED_HEADER: Self = Self(4);
+        pub const MTU: Self = Self(5);
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Ingot)]
+    pub struct Option {
+        #[ingot(zerocopy, next_layer)]
+        pub ty: OptionType,
+        pub len: u8,
+        #[ingot(var_len = "6 + (len.wrapping_sub(1) as usize) * 8")]
+        pub data: Vec<u8>,
+    }
+
+    bitflags! {
+    #[derive(Clone, Copy, Default, Debug, Hash, Eq, PartialEq)]
+    pub struct PrefixFlags: u8 {
+        const ON_LINK = 0b1000_0000;
+        const AUTONOMOUS_ADDRESS_CONFIG = 0b0100_0000;
+    }
+    }
+
+    impl NetworkRepr<u8> for PrefixFlags {
+        fn to_network(self) -> u8 {
+            self.bits()
+        }
+
+        fn from_network(val: u8) -> Self {
+            PrefixFlags::from_bits_truncate(val)
+        }
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Ingot)]
+    pub struct OptionPrefix {
+        pub prefix_len: u8,
+        #[ingot(is = "u8")]
+        pub flags: PrefixFlags,
+        pub valid_lifetime: u32be,
+        pub preferred_lifetime: u32be,
+        rsvd: u32be,
+        #[ingot(zerocopy)]
+        pub prefix: Ipv6Addr,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Ingot)]
+    #[ingot(impl_default)]
+    pub struct OptionRedirect {
+        rsvd: [u8; 6],
+        #[ingot(var_len)]
+        pub data: Vec<u8>,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Ingot)]
+    #[ingot(impl_default)]
+    pub struct OptionMtu {
+        rsvd: [u8; 2],
+        pub mtu: u32be,
+    }
 }


### PR DESCRIPTION
This PR defines additional ICMP and ICMP v6 message types for use within body transforms in OPTE -- primarily, those which can carry nested packets as their payloads. This includes a few Neighbor Discovery Protocol option classes.

To help handle ICMPv6/NDP options, the `Ingot` derive macro now allows for the `var_len` expression to be omitted (as in subparse packet definitions). This causes such headers to consume the remainder of the slice they are parsed from.