### PR TITLE
fix: decode ECN codepoint 0b11 as CongestionExperienced

### DIFF
--- a/ingot/src/ip.rs
+++ b/ingot/src/ip.rs
@@ -113,7 +113,7 @@ impl NetworkRepr<u2> for Ecn {
             0 => Ecn::NotCapable,
             1 => Ecn::Capable0,
             2 => Ecn::Capable1,
-            3 => Ecn::Capable0,
+            3 => Ecn::CongestionExperienced,
             _ => panic!("outside bounds of u2"),
         }
     }
@@ -128,7 +128,7 @@ impl TryFrom<u2> for Ecn {
             0 => Ok(Ecn::NotCapable),
             1 => Ok(Ecn::Capable0),
             2 => Ok(Ecn::Capable1),
-            3 => Ok(Ecn::Capable0),
+            3 => Ok(Ecn::CongestionExperienced),
             _ => Err(ParseError::IllegalValue),
         }
     }

--- a/ingot/src/tests.rs
+++ b/ingot/src/tests.rs
@@ -15,7 +15,8 @@ use crate::{
     },
     types::{
         primitives::*, util::RepeatedView, Accessor, Emit, HeaderLen,
-        HeaderParse, Ipv6Addr, NextLayer, ParseError, ToOwnedPacket,
+        HeaderParse, Ipv6Addr, NetworkRepr, NextLayer, ParseError,
+        ToOwnedPacket,
     },
     udp::{_Udp_ingot_impl::UdpPart0, Udp, UdpRef, ValidUdp},
     Ingot,
@@ -660,4 +661,20 @@ fn choice_packet() {
     assert_eq!(next, Some(ChoiceType::A));
     let p2 = p_ref.to_owned(None).unwrap();
     assert_eq!(p, p2);
+}
+
+#[test]
+fn ecn_round_trips_all_codepoints() {
+    let cases = [
+        (0u8, Ecn::NotCapable),
+        (1u8, Ecn::Capable0),
+        (2u8, Ecn::Capable1),
+        (3u8, Ecn::CongestionExperienced),
+    ];
+
+    for (wire, variant) in cases {
+        assert_eq!(Ecn::from_network(wire), variant);
+        assert_eq!(Ecn::try_from(wire).unwrap(), variant);
+        assert_eq!(variant.to_network(), wire);
+    }
 }


### PR DESCRIPTION
`Ecn::from_network` and `Ecn::try_from` both mapped the wire value 3 (CE, "Congestion Experienced") to `Ecn::Capable0`, silently collapsing the CE marking into ECT(1) on the next serialisation and dropping the congestion signal. Decode it to the existing `Ecn::CongestionExperienced` variant instead so all four RFC 3168 codepoints round-trip.